### PR TITLE
update autoRIFT to version 1.0.7

### DIFF
--- a/geo_autoRIFT/SConscript
+++ b/geo_autoRIFT/SConscript
@@ -22,6 +22,7 @@ import os
 Import('envcontrib')
 package = 'geo_autoRIFT'
 envgeoAutorift = envcontrib.Clone()
+envgeoAutorift.MergeFlags('-std=c++11')
 envgeoAutorift['PACKAGE'] = envcontrib['PACKAGE'] + '/' + package
 install = envcontrib['PRJ_SCONS_INSTALL'] + '/' + envgeoAutorift['PACKAGE']
 listFiles = ['__init__.py']

--- a/geo_autoRIFT/autoRIFT/bindings/autoriftcoremodule.cpp
+++ b/geo_autoRIFT/autoRIFT/bindings/autoriftcoremodule.cpp
@@ -41,6 +41,7 @@
 #include "iostream"
 #include "numpy/arrayobject.h"
 #include "opencv2/imgproc/imgproc.hpp"
+#include "opencv2/imgproc/types_c.h"
 #include "opencv2/highgui/highgui.hpp"
 #include "opencv2/core/core.hpp"
 

--- a/geo_autoRIFT/geogrid/bindings/geogridmodule.cpp
+++ b/geo_autoRIFT/geogrid/bindings/geogridmodule.cpp
@@ -403,6 +403,7 @@ PyObject* setRO2VYFilename(PyObject *self, PyObject *args)
     return Py_BuildValue("i", 0);
 }
 
+
 PyObject* setLookSide(PyObject *self, PyObject *args)
 {
     uint64_t ptr;

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -69,6 +69,8 @@ def cmdLineParse():
             help='Input pixel offsets to vx conversion coefficients file name')
     parser.add_argument('-vy', '--input_vy', dest='offset2vy', type=str, required=False,
             help='Input pixel offsets to vy conversion coefficients file name')
+    parser.add_argument('-ssm', '--input_ssm', dest='stable_surface_mask', type=str, required=False,
+            help='Input stable surface mask file name')
     parser.add_argument('-fo', '--flag_optical', dest='optical_flag', type=bool, required=False, default=0,
             help='flag for reading optical data (e.g. Landsat): use 1 for on and 0 (default) for off')
     parser.add_argument('-nc', '--sensor_flag_netCDF', dest='nc_sensor', type=str, required=False, default=None,
@@ -127,6 +129,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     import numpy as np
 #    import isceobj
     import time
+    import subprocess
     
     
     obj = autoRIFT()
@@ -144,6 +147,20 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
 
     obj.I1 = I1
     obj.I2 = I2
+
+    # test with lena image (533 X 533)
+#    obj.ChipSizeMinX=16
+#    obj.ChipSizeMaxX=32
+#    obj.ChipSize0X=16
+#    obj.SkipSampleX=16
+#    obj.SkipSampleY=16
+
+    # test with Venus image (407 X 407)
+#    obj.ChipSizeMinX=8
+#    obj.ChipSizeMaxX=16
+#    obj.ChipSize0X=8
+#    obj.SkipSampleX=8
+#    obj.SkipSampleY=8
     
     
     # create the grid if it does not exist
@@ -191,7 +208,6 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     if CSMINx0 is not None:
         obj.ChipSizeMaxX = CSMAXx0
         obj.ChipSizeMinX = CSMINx0
-        obj.ChipSize0X = np.min(CSMINx0[CSMINx0!=nodata])
         chipsizex0 = float(str.split(subprocess.getoutput('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
         try:
             pixsizex = float(str.split(subprocess.getoutput('fgrep "Ground range pixel size:" testGeogrid.txt'))[-1])
@@ -201,8 +217,11 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
 #        obj.ChipSize0X = np.min(CSMINx0[CSMINx0!=nodata])
         RATIO_Y2X = CSMINy0/CSMINx0
         obj.ScaleChipSizeY = np.mean(RATIO_Y2X[(CSMINx0!=nodata)&(CSMINy0!=nodata)])
+#        obj.ChipSizeMaxX = obj.ChipSizeMaxX / obj.ChipSizeMaxX * 544
+#        obj.ChipSizeMinX = obj.ChipSizeMinX / obj.ChipSizeMinX * 68
     else:
         if ((optflag == 1)&(xGrid is not None)):
+#            print('test')
             obj.ChipSizeMaxX = 32
             obj.ChipSizeMinX = 16
             obj.ChipSize0X = 16
@@ -254,7 +273,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
 
 #    obj.sparseSearchSampleRate = 16
 
-#    obj.OverSampleRatio = 32
+    obj.OverSampleRatio = 64
 
     #   OverSampleRatio can be assigned as a scalar (such as the above line) or as a Python dictionary below for intellgient use (ChipSize-dependent).
     #   Here, four chip sizes are used: ChipSize0X*[1,2,4,8] and four OverSampleRatio are considered [16,32,64,128]. The intelligent selection of OverSampleRatio (as a function of chip size) was determined by analyzing various combinations of (OverSampleRatio and chip size) and comparing the resulting image quality and statistics with the reference scenario (where the largest OverSampleRatio of 128 and chip size of ChipSize0X*8 are considered).
@@ -352,6 +371,11 @@ if __name__ == '__main__':
     if inps.optical_flag == 1:
         data_m = loadProductOptical(inps.indir_m)
         data_s = loadProductOptical(inps.indir_s)
+        # test with lena/Venus image
+#        import scipy.io as sio
+#        conts = sio.loadmat(inps.indir_m)
+#        data_m = conts['I']
+#        data_s = conts['I1']
     else:
         data_m = loadProduct(inps.indir_m)
         data_s = loadProduct(inps.indir_s)
@@ -421,6 +445,14 @@ if __name__ == '__main__':
         band=None
         ds=None
 
+    if inps.stable_surface_mask is not None:
+        ds = gdal.Open(inps.stable_surface_mask)
+        band = ds.GetRasterBand(1)
+        SSM = band.ReadAsArray()
+        SSM = SSM.astype('bool')
+        band=None
+        ds=None
+
 
     Dx, Dy, InterpMask, ChipSizeX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0, noDataMask, inps.optical_flag, nodata)
 
@@ -447,6 +479,8 @@ if __name__ == '__main__':
     CHIPSIZEX[noDataMask] = 0
     SEARCHLIMITX[noDataMask] = 0
     SEARCHLIMITY[noDataMask] = 0
+    if SSM is not None:
+        SSM[noDataMask] = False
 
     import scipy.io as sio
     sio.savemat('offset.mat',{'Dx':DX,'Dy':DY,'InterpMask':INTERPMASK,'ChipSizeX':CHIPSIZEX})
@@ -491,6 +525,7 @@ if __name__ == '__main__':
 
 
         if inps.offset2vx is not None:
+            
             ds = gdal.Open(inps.offset2vx)
             band = ds.GetRasterBand(1)
             offset2vx_1 = band.ReadAsArray()
@@ -511,6 +546,8 @@ if __name__ == '__main__':
             VY = offset2vy_1 * DX + offset2vy_2 * DY
             VX = VX.astype(np.float32)
             VY = VY.astype(np.float32)
+            
+            ############ write velocity output in Geotiff format
 
             outRaster = driver.Create("velocity.tif", int(xGrid.shape[1]), int(xGrid.shape[0]), 2, gdal.GDT_Float32)
             outRaster.SetGeoTransform(tran)
@@ -522,97 +559,193 @@ if __name__ == '__main__':
             outband.WriteArray(VY)
             outband.FlushCache()
             
-            ########################################################################################
-            ############   netCDF packaging for Sentinel and Landsat dataset; can add other sensor format as well
-            if inps.nc_sensor == "S":
-                
-                rangePixelSize = float(str.split(runCmd('fgrep "Ground range pixel size:" testGeogrid.txt'))[4])
-                azimuthPixelSize = float(str.split(runCmd('fgrep "Azimuth pixel size:" testGeogrid.txt'))[3])
-                dt = float(str.split(runCmd('fgrep "Repeat Time:" testGeogrid.txt'))[2])
-                epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
-#                print (str(rangePixelSize)+"      "+str(azimuthPixelSize))
-
-
-                runCmd('topsinsar_filename.py')
-#                import scipy.io as sio
-                conts = sio.loadmat('topsinsar_filename.mat')
-                master_filename = conts['master_filename'][0]
-                slave_filename = conts['slave_filename'][0]
-                master_split = str.split(master_filename,'_')
-                slave_split = str.split(slave_filename,'_')
-
-                import netcdf_output as no
-                version = '1.0.5'
-                pair_type = 'radar'
-                detection_method = 'feature'
-                coordinates = 'radar'
-#                out_nc_filename = 'Jakobshavn.nc'
-                out_nc_filename = master_filename[0:-4]+'_'+slave_filename[0:-4]+'.nc'
-                out_nc_filename = './' + out_nc_filename
-                roi_valid_percentage = np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*100.0
-                CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
-                
-
-                
-                from datetime import date
-                d0 = date(np.int(master_split[5][0:4]),np.int(master_split[5][4:6]),np.int(master_split[5][6:8]))
-                d1 = date(np.int(slave_split[5][0:4]),np.int(slave_split[5][4:6]),np.int(slave_split[5][6:8]))
-                date_dt_base = d1 - d0
-                date_dt = np.float64(np.abs(date_dt_base.days))
-                if date_dt_base.days < 0:
-                    date_ct = d1 + (d0 - d1)/2
-                    date_center = date_ct.strftime("%Y%m%d")
-                else:
-                    date_ct = d0 + (d1 - d0)/2
-                    date_center = date_ct.strftime("%Y%m%d")
+            ############ prepare for netCDF packaging
             
-                IMG_INFO_DICT = {'mission_img1':master_split[0][0],'sensor_img1':'C','satellite_img1':master_split[0][1:3],'acquisition_img1':master_split[5][0:8],'absolute_orbit_number_img1':master_split[7],'mission_data_take_ID_img1':master_split[8],'product_unique_ID_img1':master_split[9][0:4],'mission_img2':slave_split[0][0],'sensor_img2':'C','satellite_img2':slave_split[0][1:3],'acquisition_img2':slave_split[5][0:8],'absolute_orbit_number_img2':slave_split[7],'mission_data_take_ID_img2':slave_split[8],'product_unique_ID_img2':slave_split[9][0:4],'date_dt':date_dt,'date_center':date_center,'roi_valid_percentage':roi_valid_percentage,'autoRIFT_software_version':version}
-
-                no.netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, rangePixelSize, azimuthPixelSize, dt, epsg, srs, tran, out_nc_filename, pair_type, detection_method, coordinates, IMG_INFO_DICT)
-
-            elif inps.nc_sensor == "L":
+            if inps.nc_sensor is not None:
                 
-                XPixelSize = float(str.split(runCmd('fgrep "X-direction pixel size:" testGeogrid.txt'))[3])
-                YPixelSize = float(str.split(runCmd('fgrep "Y-direction pixel size:" testGeogrid.txt'))[3])
-                epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
+                vxrefname = str.split(runCmd('fgrep "Velocities:" testGeogrid.txt'))[1]
+                vyrefname = str.split(runCmd('fgrep "Velocities:" testGeogrid.txt'))[2]
+                sxname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[1][:-4]+"s.tif"
+                syname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[2][:-4]+"s.tif"
+                maskname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[2][:-8]+"masks.tif"
+                xoff = int(str.split(runCmd('fgrep "Origin index (in DEM) of geogrid:" testGeogrid.txt'))[6])
+                yoff = int(str.split(runCmd('fgrep "Origin index (in DEM) of geogrid:" testGeogrid.txt'))[7])
+                xcount = int(str.split(runCmd('fgrep "Dimensions of geogrid:" testGeogrid.txt'))[3])
+                ycount = int(str.split(runCmd('fgrep "Dimensions of geogrid:" testGeogrid.txt'))[5])
+            
+                ds = gdal.Open(vxrefname)
+                band = ds.GetRasterBand(1)
+                VXref = band.ReadAsArray(xoff, yoff, xcount, ycount)
+                ds = None
+                band = None
                 
-                master_filename = inps.indir_m
-                slave_filename = inps.indir_s
-                master_split = str.split(master_filename,'_')
-                slave_split = str.split(slave_filename,'_')
+                ds = gdal.Open(vyrefname)
+                band = ds.GetRasterBand(1)
+                VYref = band.ReadAsArray(xoff, yoff, xcount, ycount)
+                ds = None
+                band = None
                 
-                import netcdf_output as no
-                version = '1.0.5'
-                pair_type = 'optical'
-                detection_method = 'feature'
-                coordinates = 'map'
-#                out_nc_filename = 'Jakobshavn_opt.nc'
-                out_nc_filename = master_filename[0:-4]+'_'+slave_filename[0:-4]+'.nc'
-                out_nc_filename = './' + out_nc_filename
-                roi_valid_percentage = np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*100.0
-                CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
+                ds = gdal.Open(sxname)
+                band = ds.GetRasterBand(1)
+                SX = band.ReadAsArray(xoff, yoff, xcount, ycount)
+                ds = None
+                band = None
+                
+                ds = gdal.Open(syname)
+                band = ds.GetRasterBand(1)
+                SY = band.ReadAsArray(xoff, yoff, xcount, ycount)
+                ds = None
+                band = None
+                
+                ds = gdal.Open(maskname)
+                band = ds.GetRasterBand(1)
+                MM = band.ReadAsArray(xoff, yoff, xcount, ycount)
+                ds = None
+                band = None
+                
+                DXref = offset2vy_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * VXref - offset2vx_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * VYref
+                DYref = offset2vx_1 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * VYref - offset2vy_1 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * VXref
+                    
+                stable_count = np.sum(SSM & np.logical_not(np.isnan(DX)))
 
-                from datetime import date
-                d0 = date(np.int(master_split[3][0:4]),np.int(master_split[3][4:6]),np.int(master_split[3][6:8]))
-                d1 = date(np.int(slave_split[3][0:4]),np.int(slave_split[3][4:6]),np.int(slave_split[3][6:8]))
-                date_dt_base = d1 - d0
-                date_dt = np.float64(np.abs(date_dt_base.days))
-                if date_dt_base.days < 0:
-                    date_ct = d1 + (d0 - d1)/2
-                    date_center = date_ct.strftime("%Y%m%d")
+                if stable_count == 0:
+                    stable_shift_applied = 0
                 else:
-                    date_ct = d0 + (d1 - d0)/2
-                    date_center = date_ct.strftime("%Y%m%d")
-
-                IMG_INFO_DICT = {'mission_img1':master_split[0][0],'sensor_img1':master_split[0][1],'satellite_img1':np.float64(master_split[0][2:4]),'correction_level_img1':master_split[1],'path_img1':np.float64(master_split[2][0:3]),'row_img1':np.float64(master_split[2][3:6]),'acquisition_date_img1':master_split[3][0:8],'processing_date_img1':master_split[4][0:8],'collection_number_img1':np.float64(master_split[5]),'collection_category_img1':master_split[6],'mission_img2':slave_split[0][0],'sensor_img2':slave_split[0][1],'satellite_img2':np.float64(slave_split[0][2:4]),'correction_level_img2':slave_split[1],'path_img2':np.float64(slave_split[2][0:3]),'row_img2':np.float64(slave_split[2][3:6]),'acquisition_date_img2':slave_split[3][0:8],'processing_date_img2':slave_split[4][0:8],'collection_number_img2':np.float64(slave_split[5]),'collection_category_img2':slave_split[6],'date_dt':date_dt,'date_center':date_center,'roi_valid_percentage':roi_valid_percentage,'autoRIFT_software_version':version}
+                    stable_shift_applied = 1
                 
-                no.netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type, detection_method, coordinates, IMG_INFO_DICT)
+                if stable_shift_applied == 1:
+                    temp = DX.copy() - DXref.copy()
+                    temp[np.logical_not(SSM)] = np.nan
+                    dx_mean_shift = np.median(temp[(temp > -5)&(temp < 5)])
+                    DX = DX - dx_mean_shift
+                    
+                    temp = DY.copy() - DYref.copy()
+                    temp[np.logical_not(SSM)] = np.nan
+                    dy_mean_shift = np.median(temp[(temp > -5)&(temp < 5)])
+                    DY = DY - dy_mean_shift
+                else:
+                    dx_mean_shift = 0.0
+                    dy_mean_shift = 0.0
+                        
+                VX = offset2vx_1 * DX + offset2vx_2 * DY
+                VY = offset2vy_1 * DX + offset2vy_2 * DY
+                VX = VX.astype(np.float32)
+                VY = VY.astype(np.float32)
+            ########################################################################################
+                ############   netCDF packaging for Sentinel and Landsat dataset; can add other sensor format as well
+                if inps.nc_sensor == "S":
+                    
+                    rangePixelSize = float(str.split(runCmd('fgrep "Ground range pixel size:" testGeogrid.txt'))[4])
+                    azimuthPixelSize = float(str.split(runCmd('fgrep "Azimuth pixel size:" testGeogrid.txt'))[3])
+                    dt = float(str.split(runCmd('fgrep "Repeat Time:" testGeogrid.txt'))[2])
+                    epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
+    #                print (str(rangePixelSize)+"      "+str(azimuthPixelSize))
 
-            elif inps.nc_sensor is None:
-                print('netCDF packaging not performed')
 
-            else:
-                raise Exception('netCDF packaging not supported for the type "{0}"'.format(inps.nc_sensor))
+                    runCmd('topsinsar_filename.py')
+    #                import scipy.io as sio
+                    conts = sio.loadmat('topsinsar_filename.mat')
+                    master_filename = conts['master_filename'][0]
+                    slave_filename = conts['slave_filename'][0]
+                    master_dt = conts['master_dt'][0]
+                    slave_dt = conts['slave_dt'][0]
+                    master_split = str.split(master_filename,'_')
+                    slave_split = str.split(slave_filename,'_')
+
+                    import netcdf_output as no
+                    version = '1.0.7'
+                    pair_type = 'radar'
+                    detection_method = 'feature'
+                    coordinates = 'radar'
+    #                out_nc_filename = 'Jakobshavn.nc'
+                    out_nc_filename = master_filename[0:-4]+'_'+slave_filename[0:-4]+'.nc'
+                    out_nc_filename = './' + out_nc_filename
+                    roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
+                    CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
+
+
+
+                    from datetime import date
+                    d0 = date(np.int(master_split[5][0:4]),np.int(master_split[5][4:6]),np.int(master_split[5][6:8]))
+                    d1 = date(np.int(slave_split[5][0:4]),np.int(slave_split[5][4:6]),np.int(slave_split[5][6:8]))
+                    date_dt_base = d1 - d0
+                    date_dt = np.float64(np.abs(date_dt_base.days))
+                    if date_dt_base.days < 0:
+                        date_ct = d1 + (d0 - d1)/2
+                        date_center = date_ct.strftime("%Y%m%d")
+                    else:
+                        date_ct = d0 + (d1 - d0)/2
+                        date_center = date_ct.strftime("%Y%m%d")
+
+                    IMG_INFO_DICT = {'mission_img1':master_split[0][0],'sensor_img1':'C','satellite_img1':master_split[0][1:3],'acquisition_img1':master_dt,'absolute_orbit_number_img1':master_split[7],'mission_data_take_ID_img1':master_split[8],'product_unique_ID_img1':master_split[9][0:4],'mission_img2':slave_split[0][0],'sensor_img2':'C','satellite_img2':slave_split[0][1:3],'acquisition_img2':slave_dt,'absolute_orbit_number_img2':slave_split[7],'mission_data_take_ID_img2':slave_split[8],'product_unique_ID_img2':slave_split[9][0:4],'date_dt':date_dt,'date_center':date_center,'roi_valid_percentage':roi_valid_percentage,'autoRIFT_software_version':version}
+                    error_vector = np.array([[0.0356, 0.0501, 0.0266, 0.0622, 0.0357, 0.0501],
+                                             [0.5194, 1.1638, 0.3319, 1.3701, 0.5191, 1.1628]])
+
+                    no.netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, SY, offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref, rangePixelSize, azimuthPixelSize, dt, epsg, srs, tran, out_nc_filename, pair_type, detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_shift_applied, dx_mean_shift, dy_mean_shift, error_vector)
+
+                elif inps.nc_sensor == "L":
+                    
+                    XPixelSize = float(str.split(runCmd('fgrep "X-direction pixel size:" testGeogrid.txt'))[3])
+                    YPixelSize = float(str.split(runCmd('fgrep "Y-direction pixel size:" testGeogrid.txt'))[3])
+                    epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
+                    
+                    master_path = inps.indir_m
+                    slave_path = inps.indir_s
+                    
+                    import os
+                    master_filename = os.path.basename(master_path)
+                    slave_filename = os.path.basename(slave_path)
+                    
+                    master_split = str.split(master_filename,'_')
+                    slave_split = str.split(slave_filename,'_')
+                    
+                    master_MTL_path = master_path[:-6]+'MTL.txt'
+                    slave_MTL_path = slave_path[:-6]+'MTL.txt'
+                    
+                    master_time = str.split(str.split(runCmd('fgrep "SCENE_CENTER_TIME" '+master_MTL_path))[2][1:-2],':')
+                    slave_time = str.split(str.split(runCmd('fgrep "SCENE_CENTER_TIME" '+slave_MTL_path))[2][1:-2],':')
+                    
+                    from datetime import time as time1
+                    master_time = time1(int(master_time[0]),int(master_time[1]),int(float(master_time[2])))
+                    slave_time = time1(int(slave_time[0]),int(slave_time[1]),int(float(slave_time[2])))
+                    
+                    import netcdf_output as no
+                    version = '1.0.7'
+                    pair_type = 'optical'
+                    detection_method = 'feature'
+                    coordinates = 'map'
+    #                out_nc_filename = 'Jakobshavn_opt.nc'
+                    out_nc_filename = master_filename[0:-4]+'_'+slave_filename[0:-4]+'.nc'
+                    out_nc_filename = './' + out_nc_filename
+                    roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
+                    CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
+
+                    from datetime import date
+                    d0 = date(np.int(master_split[3][0:4]),np.int(master_split[3][4:6]),np.int(master_split[3][6:8]))
+                    d1 = date(np.int(slave_split[3][0:4]),np.int(slave_split[3][4:6]),np.int(slave_split[3][6:8]))
+                    date_dt_base = d1 - d0
+                    date_dt = np.float64(np.abs(date_dt_base.days))
+                    if date_dt_base.days < 0:
+                        date_ct = d1 + (d0 - d1)/2
+                        date_center = date_ct.strftime("%Y%m%d")
+                    else:
+                        date_ct = d0 + (d1 - d0)/2
+                        date_center = date_ct.strftime("%Y%m%d")
+                    
+                    master_dt = master_split[3][0:8] + master_time.strftime("T%H:%M:%S")
+                    slave_dt = slave_split[3][0:8] + slave_time.strftime("T%H:%M:%S")
+
+                    IMG_INFO_DICT = {'mission_img1':master_split[0][0],'sensor_img1':master_split[0][1],'satellite_img1':np.float64(master_split[0][2:4]),'correction_level_img1':master_split[1],'path_img1':np.float64(master_split[2][0:3]),'row_img1':np.float64(master_split[2][3:6]),'acquisition_date_img1':master_dt,'processing_date_img1':master_split[4][0:8],'collection_number_img1':np.float64(master_split[5]),'collection_category_img1':master_split[6],'mission_img2':slave_split[0][0],'sensor_img2':slave_split[0][1],'satellite_img2':np.float64(slave_split[0][2:4]),'correction_level_img2':slave_split[1],'path_img2':np.float64(slave_split[2][0:3]),'row_img2':np.float64(slave_split[2][3:6]),'acquisition_date_img2':slave_dt,'processing_date_img2':slave_split[4][0:8],'collection_number_img2':np.float64(slave_split[5]),'collection_category_img2':slave_split[6],'date_dt':date_dt,'date_center':date_center,'roi_valid_percentage':roi_valid_percentage,'autoRIFT_software_version':version}
+                    
+                    error_vector = np.array([57.,57.])
+                    
+                    no.netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, SY, offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref, XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type, detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_shift_applied, dx_mean_shift, dy_mean_shift, error_vector)
+
+                elif inps.nc_sensor is None:
+                    print('netCDF packaging not performed')
+
+                else:
+                    raise Exception('netCDF packaging not supported for the type "{0}"'.format(inps.nc_sensor))
 
         print("Write Outputs Done!!!")
         print(time.time()-t1)


### PR DESCRIPTION
- eased Geogrid output handling (the program will automatically check the optional inputs provided by the user and only generate the meaningful output based on the input combinations)

- bug of grid offset in Geogrid outputs has been fixed

- bug of erroneous large values (due to radar geometry's loss of sensitivity to geocode pixel displacement to velocity at large surface slopes) in Geogrid outputs has been fixed

- autoRIFT was successfully compiled with OpenCV v3 and OpenCV v4

- netcdf output packaging (not publicly available at this moment) for autoRIFT final products is significantly improved, where error metrics are calculated at the stable surfaces wherever available, and radar range-projected velocities onto a priori flow (e.g. surface slope parallel) are also provided when ionosphere-induced azimuth error are much larger. 