### PR TITLE
Allow usage of GDAL's virtual file systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 
 ```diff
 + parallel computing for NCC
-+ support of urls for input files (both images and auxiliary input files can be urls for optical data processing; only auxiliary input files can be urls for radar data processing)
++ support for remote input files using GDAL virtual file systems (e.g., `/vsicurl/https://...`)
++   see: https://gdal.org/user/virtual_file_systems.html
 ```
 
 
@@ -64,7 +65,7 @@ This effort was funded by the NASA MEaSUREs program in contribution to the Inter
 * the current version can be installed with the ISCE software (that supports both Cartesian and radar coordinates) or as a standalone Python module (Cartesian coordinates only)
 * when used in combination with the Geogrid Python module (https://github.com/leiyangleon/Geogrid), autoRIFT can be used for feature tracking between image pair over a grid defined in an arbitrary geographic Cartesian (northing/easting) coordinate projection
 * when the grid is provided in geographic Cartesian (northing/easting) coordinates, outputs are returned in geocoded GeoTIFF image file format with the same EPSG projection code as input search grid
-* **[NEW]** For feature tracking of optical images, the program now supports fetching optical images (Landsat-8 GeoTIFF and Sentinel-2 COG formats are included) as well as other inputs (e.g. DEM, slope, etc; all in GeoTIFF format) from either local machine or URL links. For feature tracking of radar images, the program now supports fetching auxilliary inputs (e.g. DEM, slope, etc; all in GeoTIFF format) from either local machine or URL links. See the changes on the Geogrid [commands](https://github.com/leiyangleon/Geogrid). When using the autoRIFT commands below, users need to append a url flag: "-urlflag 1" for using URL links, and "-urlflag 0" (default; can be omitted) for using files on local machine. 
+* **[NEW]** For feature tracking of optical images, the program now supports fetching optical images (Landsat-8 GeoTIFF and Sentinel-2 COG formats are included) as well as other inputs (e.g. DEM, slope, etc; all in GeoTIFF format) from either local machine or remotely using [GDAL virtual file systems](https://gdal.org/user/virtual_file_systems.html) (e.g., `/vsicurl/https://...`). For feature tracking of radar images, the program now supports fetching auxiliary inputs (e.g. DEM, slope, etc; all in GeoTIFF format) from either local machine or remotely. See the changes on the Geogrid [commands](https://github.com/leiyangleon/Geogrid).
 * **[NEW]** parallel computing has been added for Normalized Cross-Correlation (NCC). When using the autoRIFT commands below, users need to append a multiprocessing flag: "-mpflag $num" with "$num" being the number of threads used; if not specified, the single-core version is used. 
 
 ## 4. Possible Future Development

--- a/geo_autoRIFT/autoRIFT/__init__.py
+++ b/geo_autoRIFT/autoRIFT/__init__.py
@@ -12,3 +12,5 @@ try:
 except ImportError:
     # this means ISCE support not available. Don't raise error. Allow standalone use
     pass
+
+__version__ = '1.1.1'

--- a/geo_autoRIFT/geogrid/Geogrid.py
+++ b/geo_autoRIFT/geogrid/Geogrid.py
@@ -77,10 +77,7 @@ class Geogrid(Component):
             raise Exception('At least the DEM parameter must be set for geogrid')
 
         from osgeo import gdal, osr
-        if self.urlflag == 1:
-            ds = gdal.Open('/vsicurl/%s' %(self.demname))
-        else:
-            ds = gdal.Open(self.demname, gdal.GA_ReadOnly)
+        ds = gdal.Open(self.demname, gdal.GA_ReadOnly)
         srs = osr.SpatialReference()
         srs.ImportFromWkt(ds.GetProjection())
         srs.AutoIdentifyEPSG()
@@ -96,10 +93,7 @@ class Geogrid(Component):
         else:
             raise Exception('Non-standard coordinate system encountered')
         if not epsgstr:  #Empty string->use shell command gdalsrsinfo for last trial
-            if self.urlflag == 1:
-                cmd = 'gdalsrsinfo -o epsg /vsicurl/{0}'.format(self.demname)
-            else:
-                cmd = 'gdalsrsinfo -o epsg {0}'.format(self.demname)
+            cmd = 'gdalsrsinfo -o epsg {0}'.format(self.demname)
             epsgstr = subprocess.check_output(cmd, shell=True)
 #            pdb.set_trace()
             epsgstr = re.findall("EPSG:(\d+)", str(epsgstr))[0]
@@ -280,9 +274,6 @@ class Geogrid(Component):
         geogrid.setRO2VYFilename_Py( self._geogrid, self.winro2vyname)
         geogrid.setLookSide_Py(self._geogrid, self.lookSide)
         geogrid.setNodataOut_Py(self._geogrid, self.nodata_out)
-        if self.urlflag is None:
-            self.urlflag = 0
-        geogrid.setUrlFlag_Py(self._geogrid, self.urlflag)
 
         self._orbit  = self.orbit.exportToC()
         geogrid.setOrbit_Py(self._geogrid, self._orbit)
@@ -330,8 +321,7 @@ class Geogrid(Component):
         self.csmaxxname = None
         self.csmaxyname = None
         self.ssmname = None
-        self.urlflag = None
-        
+
         ##Output related parameters
         self.winlocname = None
         self.winoffname = None

--- a/geo_autoRIFT/geogrid/GeogridOptical.py
+++ b/geo_autoRIFT/geogrid/GeogridOptical.py
@@ -48,8 +48,8 @@ class GeogridOptical():
         '''
 
         ##Determine appropriate EPSG system
-        self.epsgDem = self.getProjectionSystem(self.demname, self.urlflag)
-        self.epsgDat = self.getProjectionSystem(self.dat1name, self.urlflag)
+        self.epsgDem = self.getProjectionSystem(self.demname)
+        self.epsgDat = self.getProjectionSystem(self.dat1name)
         
         ###Determine extent of data needed
         bbox = self.determineBbox()
@@ -59,7 +59,7 @@ class GeogridOptical():
         self.geogrid()
 
 
-    def getProjectionSystem(self, filename, urlflag):
+    def getProjectionSystem(self, filename):
         '''
         Testing with Greenland.
         '''
@@ -67,10 +67,7 @@ class GeogridOptical():
             raise Exception('File {0} does not exist'.format(filename))
 
         from osgeo import gdal, osr
-        if urlflag == 1:
-            ds = gdal.Open('/vsicurl/%s' %(filename))
-        else:
-            ds = gdal.Open(filename, gdal.GA_ReadOnly)
+        ds = gdal.Open(filename, gdal.GA_ReadOnly)
         srs = osr.SpatialReference()
         srs.ImportFromWkt(ds.GetProjection())
         srs.AutoIdentifyEPSG()
@@ -86,10 +83,7 @@ class GeogridOptical():
         else:
             raise Exception('Non-standard coordinate system encountered')
         if not epsgstr:  #Empty string->use shell command gdalsrsinfo for last trial
-            if urlflag == 1:
-                cmd = 'gdalsrsinfo -o epsg /vsicurl/{0}'.format(filename)
-            else:
-                cmd = 'gdalsrsinfo -o epsg {0}'.format(filename)
+            cmd = 'gdalsrsinfo -o epsg {0}'.format(filename)
             epsgstr = subprocess.check_output(cmd, shell=True)
 #            pdb.set_trace()
             epsgstr = re.findall("EPSG:(\d+)", str(epsgstr))[0]
@@ -151,23 +145,16 @@ class GeogridOptical():
 
         self._xlim = [np.min(xyzs[:,0]), np.max(xyzs[:,0])]
         self._ylim = [np.min(xyzs[:,1]), np.max(xyzs[:,1])]
+                
+                
+                
+    
+    
 
-                
-                
-                
-    
-    
     def geogrid(self):
         
         #   For now print inputs that were obtained
-        
-        urlflag = self.urlflag
-        
-        if urlflag == 1:
-            print("\nReading input images into memory directly from URL's")
-        else:
-            print("\nReading input images locally from files")
-    
+
         print("\nOptical Image parameters: ")
         print("X-direction coordinate: " + str(self.startingX) + "  " + str(self.XSize))
         print("Y-direction coordinate: " + str(self.startingY) + "  " + str(self.YSize))
@@ -231,20 +218,6 @@ class GeogridOptical():
         import struct
         
 #        pdb.set_trace()
-        if urlflag == 1:
-            self.demname = '/vsicurl/%s' %(self.demname)
-            self.dhdxname = '/vsicurl/%s' %(self.dhdxname)
-            self.dhdyname = '/vsicurl/%s' %(self.dhdyname)
-            self.vxname = '/vsicurl/%s' %(self.vxname)
-            self.vyname = '/vsicurl/%s' %(self.vyname)
-            self.srxname = '/vsicurl/%s' %(self.srxname)
-            self.sryname = '/vsicurl/%s' %(self.sryname)
-            self.csminxname = '/vsicurl/%s' %(self.csminxname)
-            self.csminyname = '/vsicurl/%s' %(self.csminyname)
-            self.csmaxxname = '/vsicurl/%s' %(self.csmaxxname)
-            self.csmaxyname = '/vsicurl/%s' %(self.csmaxyname)
-            self.ssmname = '/vsicurl/%s' %(self.ssmname)
-        
 
         demDS = gdal.Open(self.demname, gdal.GA_ReadOnly)
         
@@ -682,11 +655,11 @@ class GeogridOptical():
 
                     if (self.ssmname != ""):
                         ssm_raster[jj] = ssmLine[jj]
-                    
 
 
 
-                    
+
+
 
 #            pdb.set_trace()
             
@@ -753,31 +726,25 @@ class GeogridOptical():
                 
         if (self.ssmname != ""):
             ssmDS = None
-    
-
-            
 
 
 
-    def coregister(self,in1,in2,urlflag):
+
+
+
+    def coregister(self,in1,in2):
         import os
         import numpy as np
         
         from osgeo import gdal, osr
         import struct
-        
-        if urlflag == 1:
-            DS1 = gdal.Open('/vsicurl/%s' %(in1))
-        else:
-            DS1 = gdal.Open(in1, gdal.GA_ReadOnly)
+
+        DS1 = gdal.Open(in1, gdal.GA_ReadOnly)
         trans1 = DS1.GetGeoTransform()
         xsize1 = DS1.RasterXSize
         ysize1 = DS1.RasterYSize
-        
-        if urlflag == 1:
-            DS2 = gdal.Open('/vsicurl/%s' %(in2))
-        else:
-            DS2 = gdal.Open(in2, gdal.GA_ReadOnly)
+
+        DS2 = gdal.Open(in2, gdal.GA_ReadOnly)
         trans2 = DS2.GetGeoTransform()
         xsize2 = DS2.RasterXSize
         ysize2 = DS2.RasterYSize
@@ -826,26 +793,6 @@ class GeogridOptical():
 
         trans = (W, trans1[1], 0.0, N, 0.0, trans1[5])
 
-        if urlflag == 0:
-            
-            I1 = DS1.ReadAsArray(xoff=x1a, yoff=y1a, xsize=x1b-x1a+1, ysize=y1b-y1a+1)
-            I2 = DS2.ReadAsArray(xoff=x2a, yoff=y2a, xsize=x2b-x2a+1, ysize=y2b-y2a+1)
-
-            fileformat = "GTiff"
-            driver = gdal.GetDriverByName(fileformat)
-            
-            DST1 = driver.Create(os.path.basename(in1), xsize=(x1b-x1a+1), ysize=(y1b-y1a+1), bands=1, eType=gdal.GDT_UInt16)
-            DST1.SetGeoTransform(trans)
-            DST1.SetProjection(DS1.GetProjectionRef())
-            DST1.GetRasterBand(1).WriteArray(I1)
-            DST1 = None
-            
-            DST2 = driver.Create(os.path.basename(in2), xsize=(x2b-x2a+1), ysize=(y2b-y2a+1), bands=1, eType=gdal.GDT_UInt16)
-            DST2.SetGeoTransform(trans)
-            DST2.SetProjection(DS2.GetProjectionRef())
-            DST2.GetRasterBand(1).WriteArray(I2)
-            DST2 = None
-        
         return x1a, y1a, x1b-x1a+1, y1b-y1a+1, x2a, y2a, x2b-x2a+1, y2b-y2a+1, trans
 
 
@@ -867,7 +814,6 @@ class GeogridOptical():
         self.numberOfLines = None
         self.repeatTime = None
         self.chipSizeX0 = None
-        self.urlflag = None
 
         ##Input related parameters
         self.dat1name = None

--- a/geo_autoRIFT/geogrid/bindings/geogridmodule.cpp
+++ b/geo_autoRIFT/geogrid/bindings/geogridmodule.cpp
@@ -430,18 +430,6 @@ PyObject* setNodataOut(PyObject *self, PyObject *args)
     return Py_BuildValue("i", 0);
 }
 
-PyObject* setUrlFlag(PyObject *self, PyObject *args)
-{
-    uint64_t ptr;
-    int urlflag;
-    if (!PyArg_ParseTuple(args, "Ki", &ptr, &urlflag))
-    {
-        return NULL;
-    }
-    
-    ((geoGrid*)(ptr))->urlflag = urlflag;
-    return Py_BuildValue("i", 0);
-}
 
 PyObject* setOrbit(PyObject *self, PyObject *args)
 {

--- a/geo_autoRIFT/geogrid/include/geogrid.h
+++ b/geo_autoRIFT/geogrid/include/geogrid.h
@@ -69,7 +69,6 @@ struct geoGrid
     int nPixels;
     int lookSide;
     int nodata_out;
-    int urlflag;
     double incidenceAngle;
 
     //Output file names

--- a/geo_autoRIFT/geogrid/include/geogridmodule.h
+++ b/geo_autoRIFT/geogrid/include/geogridmodule.h
@@ -53,7 +53,6 @@ extern "C"
         PyObject * setOrbit(PyObject *, PyObject *);
         PyObject * setLookSide(PyObject *, PyObject *);
         PyObject * setNodataOut(PyObject *, PyObject *);
-        PyObject * setUrlFlag(PyObject *, PyObject *);
 
         PyObject * setWindowLocationsFilename(PyObject *, PyObject *);
         PyObject * setWindowOffsetsFilename(PyObject *, PyObject *);
@@ -92,7 +91,6 @@ static PyMethodDef geogrid_methods[] =
         {"setOrbit_Py", setOrbit, METH_VARARGS, " "},
         {"setLookSide_Py", setLookSide, METH_VARARGS, " "},
         {"setNodataOut_Py", setNodataOut, METH_VARARGS, " "},
-        {"setUrlFlag_Py", setUrlFlag, METH_VARARGS, " "},
         {"setXLimits_Py", setXLimits, METH_VARARGS, " "},
         {"setYLimits_Py", setYLimits, METH_VARARGS, " "},
         {"setWindowLocationsFilename_Py", setWindowLocationsFilename, METH_VARARGS, " "},

--- a/geo_autoRIFT/geogrid/src/geogrid.cpp
+++ b/geo_autoRIFT/geogrid/src/geogrid.cpp
@@ -46,15 +46,7 @@ void geoGrid::geogrid()
     double deg2rad = M_PI/180.0;
 
     //For now print inputs that were obtained
-    
-    if (urlflag == 1){
-        std::cout << "\nReading input images into memory directly from URL's\n";
-    }
-    else
-    {
-        std::cout << "\nReading input images locally from files\n";
-    }
-    
+
     std::cout << "\nRadar parameters: \n";
     std::cout << "Range: " << startingRange << "  " << dr << "\n";
     std::cout << "Azimuth: " << sensingStart << "  " << prf << "\n";
@@ -152,23 +144,7 @@ void geoGrid::geogrid()
     GDALDataset* ssmDS = NULL;
 
     double geoTrans[6];
-    
-    std::string url ("/vsicurl/");
-    if (urlflag == 1)
-    {
-        demname = url + demname;
-        dhdxname = url + dhdxname;
-        dhdyname = url + dhdyname;
-        vxname = url + vxname;
-        vyname = url + vyname;
-        srxname = url + srxname;
-        sryname = url + sryname;
-        csminxname = url + csminxname;
-        csminyname = url + csminyname;
-        csmaxxname = url + csmaxxname;
-        csmaxyname = url + csmaxyname;
-        ssmname = url + ssmname;
-    }
+
     demDS = reinterpret_cast<GDALDataset *>(GDALOpenShared(demname.c_str(), GA_ReadOnly));
     if (dhdxname != "")
     {

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -75,8 +75,6 @@ def cmdLineParse():
             help='flag for reading optical data (e.g. Landsat): use 1 for on and 0 (default) for off')
     parser.add_argument('-nc', '--sensor_flag_netCDF', dest='nc_sensor', type=str, required=False, default=None,
             help='flag for packaging output formatted for Sentinel ("S") and Landsat ("L") dataset; default is None')
-    parser.add_argument('-urlflag', '--urlflag', dest='urlflag', type=int, required=False, default=0,
-            help='flag for reading and coregistering optical data (GeoTIFF images, e.g. Landsat): use 1 for url read and 0 (default) for local machine read')
     parser.add_argument('-mpflag', '--mpflag', dest='mpflag', type=int, required=False, default=0,
             help='number of threads for multiple threading (default is specified by 0, which uses the original single-core version and surpasses the multithreading routine)')
 
@@ -101,39 +99,21 @@ def loadProduct(filename):
     return img
 
 
-def loadProductOptical(filename):
+def loadProductOptical(file_m, file_s):
     import numpy as np
     '''
     Load the product using Product Manager.
     '''
-    ds = gdal.Open(filename)
-#    pdb.set_trace()
-    band = ds.GetRasterBand(1)
-    
-    img = band.ReadAsArray()
-    img = img.astype(np.float32)
-    
-    band=None
-    ds=None
-    
-    return img
 
-
-def loadProductOpticalURL(file_m, file_s):
-    import numpy as np
-    '''
-    Load the product using Product Manager.
-    '''
-    
     from geogrid import GeogridOptical
 #    from components.contrib.geo_autoRIFT.geogrid import GeogridOptical
 
     obj = GeogridOptical()
     
-    x1a, y1a, xsize1, ysize1, x2a, y2a, xsize2, ysize2, trans = obj.coregister(file_m, file_s, 1)
+    x1a, y1a, xsize1, ysize1, x2a, y2a, xsize2, ysize2, trans = obj.coregister(file_m, file_s)
     
-    DS1 = gdal.Open('/vsicurl/%s' %(file_m))
-    DS2 = gdal.Open('/vsicurl/%s' %(file_s))
+    DS1 = gdal.Open(file_m)
+    DS2 = gdal.Open(file_s)
     
     I1 = DS1.ReadAsArray(xoff=x1a, yoff=y1a, xsize=xsize1, ysize=ysize1)
     I2 = DS2.ReadAsArray(xoff=x2a, yoff=y2a, xsize=xsize2, ysize=ysize2)
@@ -389,7 +369,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
 
 
 
-if __name__ == '__main__':
+def main():
     '''
     Main driver.
     '''
@@ -399,15 +379,9 @@ if __name__ == '__main__':
     inps = cmdLineParse()
     
     mpflag = inps.mpflag
-    
-    urlflag = inps.urlflag
-    
+
     if inps.optical_flag == 1:
-        if urlflag == 1:
-            data_m, data_s = loadProductOpticalURL(inps.indir_m, inps.indir_s)
-        else:
-            data_m = loadProductOptical(inps.indir_m)
-            data_s = loadProductOptical(inps.indir_s)
+        data_m, data_s = loadProductOptical(inps.indir_m, inps.indir_s)
         # test with lena/Venus image
 #        import scipy.io as sio
 #        conts = sio.loadmat(inps.indir_m)
@@ -609,47 +583,32 @@ if __name__ == '__main__':
                 yoff = int(str.split(runCmd('fgrep "Origin index (in DEM) of geogrid:" testGeogrid.txt'))[7])
                 xcount = int(str.split(runCmd('fgrep "Dimensions of geogrid:" testGeogrid.txt'))[3])
                 ycount = int(str.split(runCmd('fgrep "Dimensions of geogrid:" testGeogrid.txt'))[5])
-            
-                if urlflag == 1:
-                    ds = gdal.Open('/vsicurl/%s' %(vxrefname))
-                else:
-                    ds = gdal.Open(vxrefname)
+
+                ds = gdal.Open(vxrefname)
                 band = ds.GetRasterBand(1)
                 VXref = band.ReadAsArray(xoff, yoff, xcount, ycount)
                 ds = None
                 band = None
-                
-                if urlflag == 1:
-                    ds = gdal.Open('/vsicurl/%s' %(vyrefname))
-                else:
-                    ds = gdal.Open(vyrefname)
+
+                ds = gdal.Open(vyrefname)
                 band = ds.GetRasterBand(1)
                 VYref = band.ReadAsArray(xoff, yoff, xcount, ycount)
                 ds = None
                 band = None
-                
-                if urlflag == 1:
-                    ds = gdal.Open('/vsicurl/%s' %(sxname))
-                else:
-                    ds = gdal.Open(sxname)
+
+                ds = gdal.Open(sxname)
                 band = ds.GetRasterBand(1)
                 SX = band.ReadAsArray(xoff, yoff, xcount, ycount)
                 ds = None
                 band = None
-                
-                if urlflag == 1:
-                    ds = gdal.Open('/vsicurl/%s' %(syname))
-                else:
-                    ds = gdal.Open(syname)
+
+                ds = gdal.Open(syname)
                 band = ds.GetRasterBand(1)
                 SY = band.ReadAsArray(xoff, yoff, xcount, ycount)
                 ds = None
                 band = None
-                
-                if urlflag == 1:
-                    ds = gdal.Open('/vsicurl/%s' %(maskname))
-                else:
-                    ds = gdal.Open(maskname)
+
+                ds = gdal.Open(maskname)
                 band = ds.GetRasterBand(1)
                 MM = band.ReadAsArray(xoff, yoff, xcount, ycount)
                 ds = None
@@ -862,3 +821,7 @@ if __name__ == '__main__':
 
         print("Write Outputs Done!!!")
         print(time.time()-t1)
+
+
+if __name__ == '__main__':
+    main()

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -373,23 +373,35 @@ def main():
     '''
     Main driver.
     '''
+    inps = cmdLineParse()
+
+    generateAutoriftProduct(indir_m=inps.indir_m, indir_s=inps.indir_s, grid_location=inps.grid_location,
+                            init_offset=inps.init_offset, search_range=inps.search_range,
+                            chip_size_min=inps.chip_size_min,chip_size_max=inps.chip_size_max,
+                            offset2vx=inps.offset2vx, offset2vy=inps.offset2vy,
+                            stable_surface_mask=inps.stable_surface_mask, optical_flag=inps.optical_flag,
+                            nc_sensor=inps.nc_sensor, mpflag=inps.mpflag)
+
+
+def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search_range, chip_size_min, chip_size_max,
+                            offset2vx, offset2vy, stable_surface_mask, optical_flag, nc_sensor, mpflag):
+
     import numpy as np
     import time
-    
-    inps = cmdLineParse()
-    
-    mpflag = inps.mpflag
 
-    if inps.optical_flag == 1:
-        data_m, data_s = loadProductOptical(inps.indir_m, inps.indir_s)
+    # from components.contrib.geo_autoRIFT.autoRIFT import __version__ as version
+    from autoRIFT import __version__ as version
+
+    if optical_flag == 1:
+        data_m, data_s = loadProductOptical(indir_m, indir_s)
         # test with lena/Venus image
 #        import scipy.io as sio
-#        conts = sio.loadmat(inps.indir_m)
+#        conts = sio.loadmat(indir_m)
 #        data_m = conts['I']
 #        data_s = conts['I1']
     else:
-        data_m = loadProduct(inps.indir_m)
-        data_s = loadProduct(inps.indir_s)
+        data_m = loadProduct(indir_m)
+        data_s = loadProduct(indir_s)
 
 
 
@@ -403,11 +415,12 @@ def main():
     CSMINy0 = None
     CSMAXx0 = None
     CSMAXy0 = None
+    SSM = None
     noDataMask = None
     nodata = None
-    
-    if inps.grid_location is not None:
-        ds = gdal.Open(inps.grid_location)
+
+    if grid_location is not None:
+        ds = gdal.Open(grid_location)
         tran = ds.GetGeoTransform()
         proj = ds.GetProjection()
         srs = ds.GetSpatialRef()
@@ -419,9 +432,9 @@ def main():
         yGrid = band.ReadAsArray()
         band=None
         ds=None
-    
-    if inps.init_offset is not None:
-        ds = gdal.Open(inps.init_offset)
+
+    if init_offset is not None:
+        ds = gdal.Open(init_offset)
         band = ds.GetRasterBand(1)
         Dx0 = band.ReadAsArray()
         band = ds.GetRasterBand(2)
@@ -429,26 +442,26 @@ def main():
         band=None
         ds=None
 
-    if inps.search_range is not None:
-        ds = gdal.Open(inps.search_range)
+    if search_range is not None:
+        ds = gdal.Open(search_range)
         band = ds.GetRasterBand(1)
         SRx0 = band.ReadAsArray()
         band = ds.GetRasterBand(2)
         SRy0 = band.ReadAsArray()
         band=None
         ds=None
-    
-    if inps.chip_size_min is not None:
-        ds = gdal.Open(inps.chip_size_min)
+
+    if chip_size_min is not None:
+        ds = gdal.Open(chip_size_min)
         band = ds.GetRasterBand(1)
         CSMINx0 = band.ReadAsArray()
         band = ds.GetRasterBand(2)
         CSMINy0 = band.ReadAsArray()
         band=None
         ds=None
-    
-    if inps.chip_size_max is not None:
-        ds = gdal.Open(inps.chip_size_max)
+
+    if chip_size_max is not None:
+        ds = gdal.Open(chip_size_max)
         band = ds.GetRasterBand(1)
         CSMAXx0 = band.ReadAsArray()
         band = ds.GetRasterBand(2)
@@ -456,8 +469,8 @@ def main():
         band=None
         ds=None
 
-    if inps.stable_surface_mask is not None:
-        ds = gdal.Open(inps.stable_surface_mask)
+    if stable_surface_mask is not None:
+        ds = gdal.Open(stable_surface_mask)
         band = ds.GetRasterBand(1)
         SSM = band.ReadAsArray()
         SSM = SSM.astype('bool')
@@ -465,9 +478,12 @@ def main():
         ds=None
 
 
-    Dx, Dy, InterpMask, ChipSizeX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0, noDataMask, inps.optical_flag, nodata, mpflag)
 
-    if inps.optical_flag == 0:
+    Dx, Dy, InterpMask, ChipSizeX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(
+        data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0, noDataMask, optical_flag, nodata, mpflag
+    )
+
+    if optical_flag == 0:
         Dy = -Dy
 
     DX = np.zeros(origSize,dtype=np.float32) * np.nan
@@ -508,8 +524,8 @@ def main():
 #    SEARCHLIMITY = conts['SearchLimitY']
 #    #####################
 
-    if inps.grid_location is not None:
-        
+    if grid_location is not None:
+
 
         t1 = time.time()
         print("Write Outputs Start!!!")
@@ -535,9 +551,9 @@ def main():
         outband.FlushCache()
 
 
-        if inps.offset2vx is not None:
-            
-            ds = gdal.Open(inps.offset2vx)
+        if offset2vx is not None:
+
+            ds = gdal.Open(offset2vx)
             band = ds.GetRasterBand(1)
             offset2vx_1 = band.ReadAsArray()
             band = ds.GetRasterBand(2)
@@ -545,7 +561,7 @@ def main():
             band=None
             ds=None
 
-            ds = gdal.Open(inps.offset2vy)
+            ds = gdal.Open(offset2vy)
             band = ds.GetRasterBand(1)
             offset2vy_1 = band.ReadAsArray()
             band = ds.GetRasterBand(2)
@@ -571,9 +587,9 @@ def main():
             outband.FlushCache()
             
             ############ prepare for netCDF packaging
-            
-            if inps.nc_sensor is not None:
-                
+
+            if nc_sensor is not None:
+
                 vxrefname = str.split(runCmd('fgrep "Velocities:" testGeogrid.txt'))[1]
                 vyrefname = str.split(runCmd('fgrep "Velocities:" testGeogrid.txt'))[2]
                 sxname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[1][:-4]+"s.tif"
@@ -644,8 +660,8 @@ def main():
                 VY = VY.astype(np.float32)
             ########################################################################################
                 ############   netCDF packaging for Sentinel and Landsat dataset; can add other sensor format as well
-                if inps.nc_sensor == "S":
-                    
+                if nc_sensor == "S":
+
                     rangePixelSize = float(str.split(runCmd('fgrep "Ground range pixel size:" testGeogrid.txt'))[4])
                     azimuthPixelSize = float(str.split(runCmd('fgrep "Azimuth pixel size:" testGeogrid.txt'))[3])
                     dt = float(str.split(runCmd('fgrep "Repeat Time:" testGeogrid.txt'))[2])
@@ -664,7 +680,6 @@ def main():
                     slave_split = str.split(slave_filename,'_')
 
                     import netcdf_output as no
-                    version = '1.0.7'
                     pair_type = 'radar'
                     detection_method = 'feature'
                     coordinates = 'radar'
@@ -696,15 +711,15 @@ def main():
 
                     no.netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, SY, offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref, rangePixelSize, azimuthPixelSize, dt, epsg, srs, tran, out_nc_filename, pair_type, detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_shift_applied, dx_mean_shift, dy_mean_shift, error_vector)
 
-                elif inps.nc_sensor == "L":
-                    
+                elif nc_sensor == "L":
+
                     XPixelSize = float(str.split(runCmd('fgrep "X-direction pixel size:" testGeogrid.txt'))[3])
                     YPixelSize = float(str.split(runCmd('fgrep "Y-direction pixel size:" testGeogrid.txt'))[3])
                     epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
-                    
-                    master_path = inps.indir_m
-                    slave_path = inps.indir_s
-                    
+
+                    master_path = indir_m
+                    slave_path = indir_s
+
                     import os
                     master_filename = os.path.basename(master_path)
                     slave_filename = os.path.basename(slave_path)
@@ -725,7 +740,6 @@ def main():
                     slave_time = time1(int(slave_time[0]),int(slave_time[1]),int(float(slave_time[2])))
                     
                     import netcdf_output as no
-                    version = '1.0.7'
                     pair_type = 'optical'
                     detection_method = 'feature'
                     coordinates = 'map'
@@ -756,16 +770,16 @@ def main():
                     error_vector = np.array([57.,57.])
                     
                     no.netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, SY, offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref, XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type, detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_shift_applied, dx_mean_shift, dy_mean_shift, error_vector)
-        
-                elif inps.nc_sensor == "S2":
-                    
+
+                elif nc_sensor == "S2":
+
                     XPixelSize = float(str.split(runCmd('fgrep "X-direction pixel size:" testGeogrid.txt'))[3])
                     YPixelSize = float(str.split(runCmd('fgrep "Y-direction pixel size:" testGeogrid.txt'))[3])
                     epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
-                    
-                    master_path = inps.indir_m
-                    slave_path = inps.indir_s
-                    
+
+                    master_path = indir_m
+                    slave_path = indir_s
+
                     master_split = master_path.split('_')
                     slave_split = slave_path.split('_')
                     
@@ -782,7 +796,6 @@ def main():
                     slave_time = time1(int(slave_time[0]),int(slave_time[1]),int(float(slave_time[2])))
                     
                     import netcdf_output as no
-                    version = '1.0.7'
                     pair_type = 'optical'
                     detection_method = 'feature'
                     coordinates = 'map'
@@ -803,21 +816,21 @@ def main():
                     else:
                         date_ct = d0 + (d1 - d0)/2
                         date_center = date_ct.strftime("%Y%m%d")
-                
+
                     master_dt = master_split[2] + master_time.strftime("T%H:%M:%S")
                     slave_dt = slave_split[2] + slave_time.strftime("T%H:%M:%S")
-                    
+
                     IMG_INFO_DICT = {'mission_img1':master_split[0][-3],'satellite_img1':master_split[0][-2:],'correction_level_img1':master_split[4][:3],'acquisition_date_img1':master_dt,'mission_img2':slave_split[0][-3],'satellite_img2':slave_split[0][-2:],'correction_level_img2':slave_split[4][:3],'acquisition_date_img2':slave_dt,'date_dt':date_dt,'date_center':date_center,'roi_valid_percentage':roi_valid_percentage,'autoRIFT_software_version':version}
-                    
+
                     error_vector = np.array([57.,57.])
-                    
+
                     no.netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, SY, offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref, XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type, detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_shift_applied, dx_mean_shift, dy_mean_shift, error_vector)
 
-                elif inps.nc_sensor is None:
+                elif nc_sensor is None:
                     print('netCDF packaging not performed')
 
                 else:
-                    raise Exception('netCDF packaging not supported for the type "{0}"'.format(inps.nc_sensor))
+                    raise Exception('netCDF packaging not supported for the type "{0}"'.format(nc_sensor))
 
         print("Write Outputs Done!!!")
         print(time.time()-t1)

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -359,30 +359,39 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
 
 
 
-
-
-
 def main():
     '''
     Main driver.
     '''
+    inps = cmdLineParse()
+
+    generateAutoriftProduct(indir_m=inps.indir_m, indir_s=inps.indir_s, grid_location=inps.grid_location,
+                            init_offset=inps.init_offset, search_range=inps.search_range,
+                            chip_size_min=inps.chip_size_min,chip_size_max=inps.chip_size_max,
+                            offset2vx=inps.offset2vx, offset2vy=inps.offset2vy,
+                            stable_surface_mask=inps.stable_surface_mask, optical_flag=inps.optical_flag,
+                            nc_sensor=inps.nc_sensor, mpflag=inps.mpflag)
+
+
+def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search_range, chip_size_min, chip_size_max,
+                            offset2vx, offset2vy, stable_surface_mask, optical_flag, nc_sensor, mpflag):
+
     import numpy as np
     import time
-    
-    inps = cmdLineParse()
-    
-    mpflag = inps.mpflag
 
-    if inps.optical_flag == 1:
-        data_m, data_s = loadProductOptical(inps.indir_m, inps.indir_s)
+    from components.contrib.geo_autoRIFT.autoRIFT import __version__ as version
+    #  from autoRIFT import __version__ as version
+
+    if optical_flag == 1:
+        data_m, data_s = loadProductOptical(indir_m, indir_s)
         # test with lena/Venus image
 #        import scipy.io as sio
-#        conts = sio.loadmat(inps.indir_m)
+#        conts = sio.loadmat(indir_m)
 #        data_m = conts['I']
 #        data_s = conts['I1']
     else:
-        data_m = loadProduct(inps.indir_m)
-        data_s = loadProduct(inps.indir_s)
+        data_m = loadProduct(indir_m)
+        data_s = loadProduct(indir_s)
 
 
 
@@ -399,9 +408,9 @@ def main():
     SSM = None
     noDataMask = None
     nodata = None
-    
-    if inps.grid_location is not None:
-        ds = gdal.Open(inps.grid_location)
+
+    if grid_location is not None:
+        ds = gdal.Open(grid_location)
         tran = ds.GetGeoTransform()
         proj = ds.GetProjection()
         srs = ds.GetSpatialRef()
@@ -413,9 +422,9 @@ def main():
         yGrid = band.ReadAsArray()
         band=None
         ds=None
-    
-    if inps.init_offset is not None:
-        ds = gdal.Open(inps.init_offset)
+
+    if init_offset is not None:
+        ds = gdal.Open(init_offset)
         band = ds.GetRasterBand(1)
         Dx0 = band.ReadAsArray()
         band = ds.GetRasterBand(2)
@@ -423,8 +432,8 @@ def main():
         band=None
         ds=None
 
-    if inps.search_range is not None:
-        ds = gdal.Open(inps.search_range)
+    if search_range is not None:
+        ds = gdal.Open(search_range)
         band = ds.GetRasterBand(1)
         SRx0 = band.ReadAsArray()
         band = ds.GetRasterBand(2)
@@ -432,8 +441,8 @@ def main():
         band=None
         ds=None
 
-    if inps.chip_size_min is not None:
-        ds = gdal.Open(inps.chip_size_min)
+    if chip_size_min is not None:
+        ds = gdal.Open(chip_size_min)
         band = ds.GetRasterBand(1)
         CSMINx0 = band.ReadAsArray()
         band = ds.GetRasterBand(2)
@@ -441,8 +450,8 @@ def main():
         band=None
         ds=None
 
-    if inps.chip_size_max is not None:
-        ds = gdal.Open(inps.chip_size_max)
+    if chip_size_max is not None:
+        ds = gdal.Open(chip_size_max)
         band = ds.GetRasterBand(1)
         CSMAXx0 = band.ReadAsArray()
         band = ds.GetRasterBand(2)
@@ -450,8 +459,8 @@ def main():
         band=None
         ds=None
 
-    if inps.stable_surface_mask is not None:
-        ds = gdal.Open(inps.stable_surface_mask)
+    if stable_surface_mask is not None:
+        ds = gdal.Open(stable_surface_mask)
         band = ds.GetRasterBand(1)
         SSM = band.ReadAsArray()
         SSM = SSM.astype('bool')
@@ -460,9 +469,11 @@ def main():
 
 
 
-    Dx, Dy, InterpMask, ChipSizeX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0, noDataMask, inps.optical_flag, nodata, mpflag)
+    Dx, Dy, InterpMask, ChipSizeX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(
+        data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0, noDataMask, optical_flag, nodata, mpflag
+    )
 
-    if inps.optical_flag == 0:
+    if optical_flag == 0:
         Dy = -Dy
 
     DX = np.zeros(origSize,dtype=np.float32) * np.nan
@@ -503,8 +514,8 @@ def main():
 #    SEARCHLIMITY = conts['SearchLimitY']
 #    #####################
 
-    if inps.grid_location is not None:
-        
+    if grid_location is not None:
+
 
         t1 = time.time()
         print("Write Outputs Start!!!")
@@ -530,9 +541,9 @@ def main():
         outband.FlushCache()
 
 
-        if inps.offset2vx is not None:
-            
-            ds = gdal.Open(inps.offset2vx)
+        if offset2vx is not None:
+
+            ds = gdal.Open(offset2vx)
             band = ds.GetRasterBand(1)
             offset2vx_1 = band.ReadAsArray()
             band = ds.GetRasterBand(2)
@@ -540,7 +551,7 @@ def main():
             band=None
             ds=None
 
-            ds = gdal.Open(inps.offset2vy)
+            ds = gdal.Open(offset2vy)
             band = ds.GetRasterBand(1)
             offset2vy_1 = band.ReadAsArray()
             band = ds.GetRasterBand(2)
@@ -566,9 +577,9 @@ def main():
             outband.FlushCache()
             
             ############ prepare for netCDF packaging
-            
-            if inps.nc_sensor is not None:
-            
+
+            if nc_sensor is not None:
+
                 vxrefname = str.split(runCmd('fgrep "Velocities:" testGeogrid.txt'))[1]
                 vyrefname = str.split(runCmd('fgrep "Velocities:" testGeogrid.txt'))[2]
                 sxname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[1][:-4]+"s.tif"
@@ -640,8 +651,8 @@ def main():
 
             ########################################################################################
                 ############   netCDF packaging for Sentinel and Landsat dataset; can add other sensor format as well
-                if inps.nc_sensor == "S":
-                    
+                if nc_sensor == "S":
+
                     rangePixelSize = float(str.split(runCmd('fgrep "Ground range pixel size:" testGeogrid.txt'))[4])
                     azimuthPixelSize = float(str.split(runCmd('fgrep "Azimuth pixel size:" testGeogrid.txt'))[3])
                     dt = float(str.split(runCmd('fgrep "Repeat Time:" testGeogrid.txt'))[2])
@@ -659,7 +670,6 @@ def main():
                     slave_split = str.split(slave_filename,'_')
 
                     import netcdf_output as no
-                    version = '1.1.0'
                     pair_type = 'radar'
                     detection_method = 'feature'
                     coordinates = 'radar'
@@ -691,15 +701,15 @@ def main():
 
                     no.netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, SY, offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref, rangePixelSize, azimuthPixelSize, dt, epsg, srs, tran, out_nc_filename, pair_type, detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_shift_applied, dx_mean_shift, dy_mean_shift, error_vector)
 
-                elif inps.nc_sensor == "L":
-                    
+                elif nc_sensor == "L":
+
                     XPixelSize = float(str.split(runCmd('fgrep "X-direction pixel size:" testGeogrid.txt'))[3])
                     YPixelSize = float(str.split(runCmd('fgrep "Y-direction pixel size:" testGeogrid.txt'))[3])
                     epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
-                    
-                    master_path = inps.indir_m
-                    slave_path = inps.indir_s
-                    
+
+                    master_path = indir_m
+                    slave_path = indir_s
+
                     import os
                     master_filename = os.path.basename(master_path)
                     slave_filename = os.path.basename(slave_path)
@@ -720,7 +730,6 @@ def main():
                     slave_time = time1(int(slave_time[0]),int(slave_time[1]),int(float(slave_time[2])))
                     
                     import netcdf_output as no
-                    version = '1.1.0'
                     pair_type = 'optical'
                     detection_method = 'feature'
                     coordinates = 'map'
@@ -751,15 +760,15 @@ def main():
                     error_vector = np.array([57.,57.])
                     
                     no.netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, SY, offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref, XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type, detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_shift_applied, dx_mean_shift, dy_mean_shift, error_vector)
-                        
-                elif inps.nc_sensor == "S2":
+
+                elif nc_sensor == "S2":
 
                     XPixelSize = float(str.split(runCmd('fgrep "X-direction pixel size:" testGeogrid.txt'))[3])
                     YPixelSize = float(str.split(runCmd('fgrep "Y-direction pixel size:" testGeogrid.txt'))[3])
                     epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
 
-                    master_path = inps.indir_m
-                    slave_path = inps.indir_s
+                    master_path = indir_m
+                    slave_path = indir_s
 
                     master_split = master_path.split('_')
                     slave_split = slave_path.split('_')
@@ -777,7 +786,6 @@ def main():
                     slave_time = time1(int(slave_time[0]),int(slave_time[1]),int(float(slave_time[2])))
                     
                     import netcdf_output as no
-                    version = '1.1.0'
                     pair_type = 'optical'
                     detection_method = 'feature'
                     coordinates = 'map'
@@ -808,11 +816,11 @@ def main():
                     
                     no.netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, SY, offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref, XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type, detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_shift_applied, dx_mean_shift, dy_mean_shift, error_vector)
 
-                elif inps.nc_sensor is None:
+                elif nc_sensor is None:
                     print('netCDF packaging not performed')
 
                 else:
-                    raise Exception('netCDF packaging not supported for the type "{0}"'.format(inps.nc_sensor))
+                    raise Exception('netCDF packaging not supported for the type "{0}"'.format(nc_sensor))
 
         print("Write Outputs Done!!!")
         print(time.time()-t1)


### PR DESCRIPTION
Instead of modifying `http://...` paths with `/vsicurl/`, this instead:
* directly passes provided paths through to GDAL, allowing use of any [GDAL virtual file system driver](https://gdal.org/user/virtual_file_systems.html). Users would provide paths like:
  * local: `/path/to/file/...`
  * remote via url: `/vsicurl/https://...` 
  * remote on S3 (allows access to requester pays buckets): `/vsis3/...`
  * etc.
* This however does mean that one cannot assume files are co-registered, so co-registration is always performed.

Also moves main driver inside a `main()` function, and does:
```python
if __name__ == '__main__':
   main()

```
So that the test scripts can turned into [entrypoints](https://packaging.python.org/specifications/entry-points/) if vendored downstream (ideally, `geo_autoRIFT` would just provides these inside the package and add entrypoints for script access when the package is installed, but that can be tackled in a subsequent PR). 