### PR TITLE
import multiprocessing in float array correlator function

### DIFF
--- a/geo_autoRIFT/autoRIFT/autoRIFT.py
+++ b/geo_autoRIFT/autoRIFT/autoRIFT.py
@@ -1095,7 +1095,8 @@ def arImgDisp_s(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, Search
     
     import numpy as np
     from . import autoriftcore
-    
+    import multiprocessing as mp
+
     core = AUTO_RIFT_CORE()
     if core._autoriftcore is not None:
         autoriftcore.destroyAutoRiftCore_Py(core._autoriftcore)


### PR DESCRIPTION
Hi @leiyangleon,
added a missing import for multiprocessing in the float array correlator function. Should be easy to ingest.