### PR TITLE
Allow passing run info from Geogrid to autoRIFT directly

### DIFF
--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -229,7 +229,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
                 pixsizex = float(str.split(subprocess.getoutput('fgrep "X-direction pixel size:" testGeogrid.txt'))[-1])
         else:
             chipsizex0 = geogrid_run_info['chipsizex0']
-            pixsizex = geogrid_run_info.get('pixsizex', geogrid_run_info['XPixelSize'])
+            pixsizex = geogrid_run_info['XPixelSize']
         obj.ChipSize0X = int(np.ceil(chipsizex0/pixsizex/4)*4)
 #        obj.ChipSize0X = np.min(CSMINx0[CSMINx0!=nodata])
         RATIO_Y2X = CSMINy0/CSMINx0

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -590,7 +590,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                 vyrefname = str.split(runCmd('fgrep "Velocities:" testGeogrid.txt'))[2]
                 sxname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[1][:-4]+"s.tif"
                 syname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[2][:-4]+"s.tif"
-                maskname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[2][:-8]+"masks.tif"
+                maskname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[2][:-8]+"sp.tif"
                 xoff = int(str.split(runCmd('fgrep "Origin index (in DEM) of geogrid:" testGeogrid.txt'))[6])
                 yoff = int(str.split(runCmd('fgrep "Origin index (in DEM) of geogrid:" testGeogrid.txt'))[7])
                 xcount = int(str.split(runCmd('fgrep "Dimensions of geogrid:" testGeogrid.txt'))[3])

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -704,8 +704,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
     #                out_nc_filename = 'Jakobshavn.nc'
                     PPP = roi_valid_percentage * 100
-                    out_nc_filename = master_filename[0:-4]+'_X_'+slave_filename[0:-4]+'_G0240V02_P{0}{1}{2}.nc'.format(int(PPP/10),int((PPP-int(PPP/10)*10)),int((PPP-int(PPP/10)*10-int((PPP-int(PPP/10)*10)))*10))
-                    out_nc_filename = './' + out_nc_filename
+                    out_nc_filename = f"./{master_filename[0:-4]}_X_{slave_filename[0:-4]}" \
+                                      f"_G{geogrid_run_info['chipsizex0']:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
 
@@ -773,8 +773,9 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
     #                out_nc_filename = 'Jakobshavn_opt.nc'
                     PPP = roi_valid_percentage * 100
-                    out_nc_filename = master_filename[0:-8]+'_X_'+slave_filename[0:-8]+'_G0240V02_P{0}{1}{2}.nc'.format(int(PPP/10),int((PPP-int(PPP/10)*10)),int((PPP-int(PPP/10)*10-int((PPP-int(PPP/10)*10)))*10))
-                    out_nc_filename = './' + out_nc_filename
+                    out_nc_filename = f"./{master_filename[0:-8]}_X_{slave_filename[0:-8]}" \
+                                      f"_G{geogrid_run_info['chipsizex0']:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
                     from datetime import date
@@ -838,8 +839,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     coordinates = 'map'
                     roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
                     PPP = roi_valid_percentage * 100
-                    out_nc_filename = master_filename[0:-8]+'_X_'+slave_filename[0:-8]+'_G0240V02_P{0}{1}{2}.nc'.format(int(PPP/10),int((PPP-int(PPP/10)*10)),int((PPP-int(PPP/10)*10-int((PPP-int(PPP/10)*10)))*10))
-                    out_nc_filename = './' + out_nc_filename
+                    out_nc_filename = f"./{master_filename[0:-8]}_X_{slave_filename[0:-8]}" \
+                                      f"_G{geogrid_run_info['chipsizex0']:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
                     from datetime import date

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -773,7 +773,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
     #                out_nc_filename = 'Jakobshavn_opt.nc'
                     PPP = roi_valid_percentage * 100
-                    out_nc_filename = f"./{master_filename[0:-8]}_X_{slave_filename[0:-8]}" \
+                    out_nc_filename = f"./{master_filename[0:-7]}_X_{slave_filename[0:-7]}" \
                                       f"_G{geogrid_run_info['chipsizex0']:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
 
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -676,12 +676,14 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                 ############   netCDF packaging for Sentinel and Landsat dataset; can add other sensor format as well
                 if nc_sensor == "S":
                     if geogrid_run_info is None:
+                        chipsizex0 = float(str.split(runCmd('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
                         rangePixelSize = float(str.split(runCmd('fgrep "Ground range pixel size:" testGeogrid.txt'))[4])
                         azimuthPixelSize = float(str.split(runCmd('fgrep "Azimuth pixel size:" testGeogrid.txt'))[3])
                         dt = float(str.split(runCmd('fgrep "Repeat Time:" testGeogrid.txt'))[2])
                         epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
                         #  print (str(rangePixelSize)+"      "+str(azimuthPixelSize))
                     else:
+                        chipsizex0 = geogrid_run_info['chipsizex0']
                         rangePixelSize = geogrid_run_info['rangePixelSize']
                         azimuthPixelSize = geogrid_run_info['azimuthPixelSize']
                         dt = geogrid_run_info['dt']
@@ -705,7 +707,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
     #                out_nc_filename = 'Jakobshavn.nc'
                     PPP = roi_valid_percentage * 100
                     out_nc_filename = f"./{master_filename[0:-4]}_X_{slave_filename[0:-4]}" \
-                                      f"_G{geogrid_run_info['chipsizex0']:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                                      f"_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
 
@@ -736,10 +738,12 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
                 elif nc_sensor == "L":
                     if geogrid_run_info is None:
+                        chipsizex0 = float(str.split(runCmd('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
                         XPixelSize = float(str.split(runCmd('fgrep "X-direction pixel size:" testGeogrid.txt'))[3])
                         YPixelSize = float(str.split(runCmd('fgrep "Y-direction pixel size:" testGeogrid.txt'))[3])
                         epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
                     else:
+                        chipsizex0 = geogrid_run_info['chipsizex0']
                         XPixelSize = geogrid_run_info['XPixelSize']
                         YPixelSize = geogrid_run_info['YPixelSize']
                         epsg = geogrid_run_info['epsg']
@@ -774,7 +778,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
     #                out_nc_filename = 'Jakobshavn_opt.nc'
                     PPP = roi_valid_percentage * 100
                     out_nc_filename = f"./{master_filename[0:-7]}_X_{slave_filename[0:-7]}" \
-                                      f"_G{geogrid_run_info['chipsizex0']:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                                      f"_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
 
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
@@ -807,10 +811,12 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
                 elif nc_sensor == "S2":
                     if geogrid_run_info is None:
+                        chipsizex0 = float(str.split(runCmd('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
                         XPixelSize = float(str.split(runCmd('fgrep "X-direction pixel size:" testGeogrid.txt'))[3])
                         YPixelSize = float(str.split(runCmd('fgrep "Y-direction pixel size:" testGeogrid.txt'))[3])
                         epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
                     else:
+                        chipsizex0 = geogrid_run_info['chipsizex0']
                         XPixelSize = geogrid_run_info['XPixelSize']
                         YPixelSize = geogrid_run_info['YPixelSize']
                         epsg = geogrid_run_info['epsg']
@@ -840,7 +846,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
                     PPP = roi_valid_percentage * 100
                     out_nc_filename = f"./{master_filename[0:-8]}_X_{slave_filename[0:-8]}" \
-                                      f"_G{geogrid_run_info['chipsizex0']:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                                      f"_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
                     from datetime import date

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -126,7 +126,8 @@ def loadProductOptical(file_m, file_s):
     return I1, I2
 
 
-def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0, noDataMask, optflag, nodata, mpflag):
+def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0, noDataMask, optflag,
+                nodata, mpflag, geogrid_run_info=None):
     '''
     Wire and run geogrid.
     '''
@@ -220,11 +221,15 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     if CSMINx0 is not None:
         obj.ChipSizeMaxX = CSMAXx0
         obj.ChipSizeMinX = CSMINx0
-        chipsizex0 = float(str.split(subprocess.getoutput('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
-        try:
-            pixsizex = float(str.split(subprocess.getoutput('fgrep "Ground range pixel size:" testGeogrid.txt'))[-1])
-        except:
-            pixsizex = float(str.split(subprocess.getoutput('fgrep "X-direction pixel size:" testGeogrid.txt'))[-1])
+        if geogrid_run_info is None:
+            chipsizex0 = float(str.split(subprocess.getoutput('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
+            try:
+                pixsizex = float(str.split(subprocess.getoutput('fgrep "Ground range pixel size:" testGeogrid.txt'))[-1])
+            except:
+                pixsizex = float(str.split(subprocess.getoutput('fgrep "X-direction pixel size:" testGeogrid.txt'))[-1])
+        else:
+            chipsizex0 = geogrid_run_info['chipsizex0']
+            pixsizex = geogrid_run_info.get('pixsizex', geogrid_run_info['XPixelSize'])
         obj.ChipSize0X = int(np.ceil(chipsizex0/pixsizex/4)*4)
 #        obj.ChipSize0X = np.min(CSMINx0[CSMINx0!=nodata])
         RATIO_Y2X = CSMINy0/CSMINx0
@@ -379,7 +384,8 @@ def main():
 
 
 def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search_range, chip_size_min, chip_size_max,
-                            offset2vx, offset2vy, stable_surface_mask, optical_flag, nc_sensor, mpflag):
+                            offset2vx, offset2vy, stable_surface_mask, optical_flag, nc_sensor, mpflag,
+                            geogrid_run_info=None):
 
     import numpy as np
     import time
@@ -475,7 +481,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
 
     Dx, Dy, InterpMask, ChipSizeX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(
-        data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0, noDataMask, optical_flag, nodata, mpflag
+        data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0,
+        noDataMask, optical_flag, nodata, mpflag, geogrid_run_info=geogrid_run_info,
     )
 
     if optical_flag == 0:
@@ -585,16 +592,26 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
             ############ prepare for netCDF packaging
 
             if nc_sensor is not None:
-
-                vxrefname = str.split(runCmd('fgrep "Velocities:" testGeogrid.txt'))[1]
-                vyrefname = str.split(runCmd('fgrep "Velocities:" testGeogrid.txt'))[2]
-                sxname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[1][:-4]+"s.tif"
-                syname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[2][:-4]+"s.tif"
-                maskname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[2][:-8]+"sp.tif"
-                xoff = int(str.split(runCmd('fgrep "Origin index (in DEM) of geogrid:" testGeogrid.txt'))[6])
-                yoff = int(str.split(runCmd('fgrep "Origin index (in DEM) of geogrid:" testGeogrid.txt'))[7])
-                xcount = int(str.split(runCmd('fgrep "Dimensions of geogrid:" testGeogrid.txt'))[3])
-                ycount = int(str.split(runCmd('fgrep "Dimensions of geogrid:" testGeogrid.txt'))[5])
+                if geogrid_run_info is None:
+                    vxrefname = str.split(runCmd('fgrep "Velocities:" testGeogrid.txt'))[1]
+                    vyrefname = str.split(runCmd('fgrep "Velocities:" testGeogrid.txt'))[2]
+                    sxname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[1][:-4]+"s.tif"
+                    syname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[2][:-4]+"s.tif"
+                    maskname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[2][:-8]+"sp.tif"
+                    xoff = int(str.split(runCmd('fgrep "Origin index (in DEM) of geogrid:" testGeogrid.txt'))[6])
+                    yoff = int(str.split(runCmd('fgrep "Origin index (in DEM) of geogrid:" testGeogrid.txt'))[7])
+                    xcount = int(str.split(runCmd('fgrep "Dimensions of geogrid:" testGeogrid.txt'))[3])
+                    ycount = int(str.split(runCmd('fgrep "Dimensions of geogrid:" testGeogrid.txt'))[5])
+                else:
+                    vxrefname = geogrid_run_info['vxname']
+                    vyrefname = geogrid_run_info['vyname']
+                    sxname = geogrid_run_info['sxname']
+                    syname = geogrid_run_info['syname']
+                    maskname = geogrid_run_info['maskname']
+                    xoff = geogrid_run_info['xoff']
+                    yoff = geogrid_run_info['yoff']
+                    xcount = geogrid_run_info['xcount']
+                    ycount = geogrid_run_info['ycount']
 
                 ds = gdal.Open(vxrefname)
                 band = ds.GetRasterBand(1)
@@ -658,12 +675,17 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
             ########################################################################################
                 ############   netCDF packaging for Sentinel and Landsat dataset; can add other sensor format as well
                 if nc_sensor == "S":
-
-                    rangePixelSize = float(str.split(runCmd('fgrep "Ground range pixel size:" testGeogrid.txt'))[4])
-                    azimuthPixelSize = float(str.split(runCmd('fgrep "Azimuth pixel size:" testGeogrid.txt'))[3])
-                    dt = float(str.split(runCmd('fgrep "Repeat Time:" testGeogrid.txt'))[2])
-                    epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
-    #                print (str(rangePixelSize)+"      "+str(azimuthPixelSize))
+                    if geogrid_run_info is None:
+                        rangePixelSize = float(str.split(runCmd('fgrep "Ground range pixel size:" testGeogrid.txt'))[4])
+                        azimuthPixelSize = float(str.split(runCmd('fgrep "Azimuth pixel size:" testGeogrid.txt'))[3])
+                        dt = float(str.split(runCmd('fgrep "Repeat Time:" testGeogrid.txt'))[2])
+                        epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
+                        #  print (str(rangePixelSize)+"      "+str(azimuthPixelSize))
+                    else:
+                        rangePixelSize = geogrid_run_info['rangePixelSize']
+                        azimuthPixelSize = geogrid_run_info['azimuthPixelSize']
+                        dt = geogrid_run_info['dt']
+                        epsg = geogrid_run_info['epsg']
 
                     runCmd('topsinsar_filename.py')
     #                import scipy.io as sio
@@ -713,10 +735,14 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     )
 
                 elif nc_sensor == "L":
-
-                    XPixelSize = float(str.split(runCmd('fgrep "X-direction pixel size:" testGeogrid.txt'))[3])
-                    YPixelSize = float(str.split(runCmd('fgrep "Y-direction pixel size:" testGeogrid.txt'))[3])
-                    epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
+                    if geogrid_run_info is None:
+                        XPixelSize = float(str.split(runCmd('fgrep "X-direction pixel size:" testGeogrid.txt'))[3])
+                        YPixelSize = float(str.split(runCmd('fgrep "Y-direction pixel size:" testGeogrid.txt'))[3])
+                        epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
+                    else:
+                        XPixelSize = geogrid_run_info['XPixelSize']
+                        YPixelSize = geogrid_run_info['YPixelSize']
+                        epsg = geogrid_run_info['epsg']
 
                     master_path = indir_m
                     slave_path = indir_s
@@ -779,10 +805,14 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     )
 
                 elif nc_sensor == "S2":
-
-                    XPixelSize = float(str.split(runCmd('fgrep "X-direction pixel size:" testGeogrid.txt'))[3])
-                    YPixelSize = float(str.split(runCmd('fgrep "Y-direction pixel size:" testGeogrid.txt'))[3])
-                    epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
+                    if geogrid_run_info is None:
+                        XPixelSize = float(str.split(runCmd('fgrep "X-direction pixel size:" testGeogrid.txt'))[3])
+                        YPixelSize = float(str.split(runCmd('fgrep "Y-direction pixel size:" testGeogrid.txt'))[3])
+                        epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
+                    else:
+                        XPixelSize = geogrid_run_info['XPixelSize']
+                        YPixelSize = geogrid_run_info['YPixelSize']
+                        epsg = geogrid_run_info['epsg']
 
                     master_path = indir_m
                     slave_path = indir_s

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -684,8 +684,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         #  print (str(rangePixelSize)+"      "+str(azimuthPixelSize))
                     else:
                         chipsizex0 = geogrid_run_info['chipsizex0']
-                        rangePixelSize = geogrid_run_info['rangePixelSize']
-                        azimuthPixelSize = geogrid_run_info['azimuthPixelSize']
+                        rangePixelSize = geogrid_run_info['XPixelSize']
+                        azimuthPixelSize = geogrid_run_info['YPixelSize']
                         dt = geogrid_run_info['dt']
                         epsg = geogrid_run_info['epsg']
 

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -92,7 +92,7 @@ def loadProduct(filename):
     import isce
     import logging
     from imageMath import IML
-    
+
     IMG = IML.mmapFromISCE(filename, logging)
     img = IMG.bands[0]
 #    pdb.set_trace()
@@ -104,26 +104,25 @@ def loadProductOptical(file_m, file_s):
     '''
     Load the product using Product Manager.
     '''
-
     from geogrid import GeogridOptical
 #    from components.contrib.geo_autoRIFT.geogrid import GeogridOptical
 
     obj = GeogridOptical()
-    
+
     x1a, y1a, xsize1, ysize1, x2a, y2a, xsize2, ysize2, trans = obj.coregister(file_m, file_s)
-    
+
     DS1 = gdal.Open(file_m)
     DS2 = gdal.Open(file_s)
-    
+
     I1 = DS1.ReadAsArray(xoff=x1a, yoff=y1a, xsize=xsize1, ysize=ysize1)
     I2 = DS2.ReadAsArray(xoff=x2a, yoff=y2a, xsize=xsize2, ysize=ysize2)
-    
+
     I1 = I1.astype(np.float32)
     I2 = I2.astype(np.float32)
-    
+
     DS1=None
     DS2=None
-    
+
     return I1, I2
 
 
@@ -139,8 +138,8 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
 #    import isceobj
     import time
     import subprocess
-    
-    
+
+
     obj = autoRIFT()
 #    obj.configure()
 
@@ -149,7 +148,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
 #    I2 = I2.astype(np.uint8)
 
     obj.MultiThread = mpflag
-    
+
     # take the amplitude only for the radar images
     if optflag == 0:
         I1 = np.abs(I1)
@@ -171,8 +170,11 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
 #    obj.ChipSize0X=8
 #    obj.SkipSampleX=8
 #    obj.SkipSampleY=8
-    
-    
+
+    # test with small tiff images
+#    obj.SkipSampleX=16
+#    obj.SkipSampleY=16
+
     # create the grid if it does not exist
     if xGrid is None:
         m,n = obj.I1.shape
@@ -188,7 +190,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
         obj.yGrid = yGrid
 
 
-    
+
     # generate the nodata mask where offset searching will be skipped based on 1) imported nodata mask and/or 2) zero values in the image
     for ii in range(obj.xGrid.shape[0]):
         for jj in range(obj.xGrid.shape[1]):
@@ -278,7 +280,6 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     print("Uniform Data Type Done!!!")
     print(time.time()-t1)
 
-
 #    pdb.set_trace()
 
 #    obj.sparseSearchSampleRate = 16
@@ -293,9 +294,6 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
             obj.OverSampleRatio = {obj.ChipSize0X:16,obj.ChipSize0X*2:32,obj.ChipSize0X*4:64,obj.ChipSize0X*8:64}
         else:
             obj.OverSampleRatio = {obj.ChipSize0X:32,obj.ChipSize0X*2:64,obj.ChipSize0X*4:128,obj.ChipSize0X*8:128}
-
-
-
 
 
 
@@ -363,9 +361,6 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
 
 
     return obj.Dx, obj.Dy, obj.InterpMask, obj.ChipSizeX, obj.ScaleChipSizeY, obj.SearchLimitX, obj.SearchLimitY, obj.origSize, noDataMask
-
-
-
 
 
 
@@ -492,7 +487,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
     CHIPSIZEX = np.zeros(origSize,dtype=np.float32)
     SEARCHLIMITX = np.zeros(origSize,dtype=np.float32)
     SEARCHLIMITY = np.zeros(origSize,dtype=np.float32)
-    
+
     DX[0:Dx.shape[0],0:Dx.shape[1]] = Dx
     DY[0:Dy.shape[0],0:Dy.shape[1]] = Dy
     INTERPMASK[0:InterpMask.shape[0],0:InterpMask.shape[1]] = InterpMask
@@ -524,6 +519,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 #    SEARCHLIMITY = conts['SearchLimitY']
 #    #####################
 
+    netcdf_file = None
     if grid_location is not None:
 
 
@@ -573,7 +569,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
             VY = offset2vy_1 * DX + offset2vy_2 * DY
             VX = VX.astype(np.float32)
             VY = VY.astype(np.float32)
-            
+
             ############ write velocity output in Geotiff format
 
             outRaster = driver.Create("velocity.tif", int(xGrid.shape[1]), int(xGrid.shape[0]), 2, gdal.GDT_Float32)
@@ -585,7 +581,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
             outband = outRaster.GetRasterBand(2)
             outband.WriteArray(VY)
             outband.FlushCache()
-            
+
             ############ prepare for netCDF packaging
 
             if nc_sensor is not None:
@@ -629,23 +625,23 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                 MM = band.ReadAsArray(xoff, yoff, xcount, ycount)
                 ds = None
                 band = None
-                
+
                 DXref = offset2vy_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * VXref - offset2vx_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * VYref
                 DYref = offset2vx_1 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * VYref - offset2vy_1 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * VXref
-                    
+
                 stable_count = np.sum(SSM & np.logical_not(np.isnan(DX)) & (DX-DXref > -5) & (DX-DXref < 5) & (DY-DYref > -5) & (DY-DYref < 5))
 
                 if stable_count == 0:
                     stable_shift_applied = 0
                 else:
                     stable_shift_applied = 1
-                
+
                 if stable_shift_applied == 1:
                     temp = DX.copy() - DXref.copy()
                     temp[np.logical_not(SSM)] = np.nan
                     dx_mean_shift = np.median(temp[(temp > -5)&(temp < 5)])
                     DX = DX - dx_mean_shift
-                    
+
                     temp = DY.copy() - DYref.copy()
                     temp[np.logical_not(SSM)] = np.nan
                     dy_mean_shift = np.median(temp[(temp > -5)&(temp < 5)])
@@ -653,11 +649,12 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                 else:
                     dx_mean_shift = 0.0
                     dy_mean_shift = 0.0
-                        
+
                 VX = offset2vx_1 * DX + offset2vx_2 * DY
                 VY = offset2vy_1 * DX + offset2vy_2 * DY
                 VX = VX.astype(np.float32)
                 VY = VY.astype(np.float32)
+
             ########################################################################################
                 ############   netCDF packaging for Sentinel and Landsat dataset; can add other sensor format as well
                 if nc_sensor == "S":
@@ -667,7 +664,6 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     dt = float(str.split(runCmd('fgrep "Repeat Time:" testGeogrid.txt'))[2])
                     epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
     #                print (str(rangePixelSize)+"      "+str(azimuthPixelSize))
-
 
                     runCmd('topsinsar_filename.py')
     #                import scipy.io as sio
@@ -688,7 +684,6 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     PPP = roi_valid_percentage * 100
                     out_nc_filename = master_filename[0:-4]+'_X_'+slave_filename[0:-4]+'_G0240V02_P{0}{1}{2}.nc'.format(int(PPP/10),int((PPP-int(PPP/10)*10)),int((PPP-int(PPP/10)*10-int((PPP-int(PPP/10)*10)))*10))
                     out_nc_filename = './' + out_nc_filename
-                    
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
 
@@ -709,7 +704,13 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     error_vector = np.array([[0.0356, 0.0501, 0.0266, 0.0622, 0.0357, 0.0501],
                                              [0.5194, 1.1638, 0.3319, 1.3701, 0.5191, 1.1628]])
 
-                    no.netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, SY, offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref, rangePixelSize, azimuthPixelSize, dt, epsg, srs, tran, out_nc_filename, pair_type, detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_shift_applied, dx_mean_shift, dy_mean_shift, error_vector)
+                    netcdf_file = no.netCDF_packaging(
+                        VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, SY,
+                        offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
+                        rangePixelSize, azimuthPixelSize, dt, epsg, srs, tran, out_nc_filename, pair_type,
+                        detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_shift_applied,
+                        dx_mean_shift, dy_mean_shift, error_vector
+                    )
 
                 elif nc_sensor == "L":
 
@@ -723,10 +724,10 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     import os
                     master_filename = os.path.basename(master_path)
                     slave_filename = os.path.basename(slave_path)
-                    
+
                     master_split = str.split(master_filename,'_')
                     slave_split = str.split(slave_filename,'_')
-                    
+
 #                    master_MTL_path = master_path[:-6]+'MTL.txt'
 #                    slave_MTL_path = slave_path[:-6]+'MTL.txt'
 #
@@ -738,7 +739,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     from datetime import time as time1
                     master_time = time1(int(master_time[0]),int(master_time[1]),int(float(master_time[2])))
                     slave_time = time1(int(slave_time[0]),int(slave_time[1]),int(float(slave_time[2])))
-                    
+
                     import netcdf_output as no
                     pair_type = 'optical'
                     detection_method = 'feature'
@@ -761,15 +762,21 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     else:
                         date_ct = d0 + (d1 - d0)/2
                         date_center = date_ct.strftime("%Y%m%d")
-                    
+
                     master_dt = master_split[3][0:8] + master_time.strftime("T%H:%M:%S")
                     slave_dt = slave_split[3][0:8] + slave_time.strftime("T%H:%M:%S")
 
                     IMG_INFO_DICT = {'mission_img1':master_split[0][0],'sensor_img1':master_split[0][1],'satellite_img1':np.float64(master_split[0][2:4]),'correction_level_img1':master_split[1],'path_img1':np.float64(master_split[2][0:3]),'row_img1':np.float64(master_split[2][3:6]),'acquisition_date_img1':master_dt,'processing_date_img1':master_split[4][0:8],'collection_number_img1':np.float64(master_split[5]),'collection_category_img1':master_split[6],'mission_img2':slave_split[0][0],'sensor_img2':slave_split[0][1],'satellite_img2':np.float64(slave_split[0][2:4]),'correction_level_img2':slave_split[1],'path_img2':np.float64(slave_split[2][0:3]),'row_img2':np.float64(slave_split[2][3:6]),'acquisition_date_img2':slave_dt,'processing_date_img2':slave_split[4][0:8],'collection_number_img2':np.float64(slave_split[5]),'collection_category_img2':slave_split[6],'date_dt':date_dt,'date_center':date_center,'roi_valid_percentage':roi_valid_percentage,'autoRIFT_software_version':version}
-                    
+
                     error_vector = np.array([57.,57.])
-                    
-                    no.netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, SY, offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref, XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type, detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_shift_applied, dx_mean_shift, dy_mean_shift, error_vector)
+
+                    netcdf_file = no.netCDF_packaging(
+                        VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, SY,
+                        offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
+                        XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type,
+                        detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_shift_applied,
+                        dx_mean_shift, dy_mean_shift, error_vector
+                    )
 
                 elif nc_sensor == "S2":
 
@@ -782,19 +789,19 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
                     master_split = master_path.split('_')
                     slave_split = slave_path.split('_')
-                    
+
                     import os
-                    
+
                     master_filename = master_split[0][-3:]+'_'+master_split[2]+'_'+master_split[4][:3]+'_'+os.path.basename(master_path)
                     slave_filename = slave_split[0][-3:]+'_'+slave_split[2]+'_'+slave_split[4][:3]+'_'+os.path.basename(slave_path)
-                    
+
                     master_time = ['00','00','00']
                     slave_time = ['00','00','00']
-                    
+
                     from datetime import time as time1
                     master_time = time1(int(master_time[0]),int(master_time[1]),int(float(master_time[2])))
                     slave_time = time1(int(slave_time[0]),int(slave_time[1]),int(float(slave_time[2])))
-                    
+
                     import netcdf_output as no
                     pair_type = 'optical'
                     detection_method = 'feature'
@@ -804,7 +811,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     out_nc_filename = master_filename[0:-8]+'_X_'+slave_filename[0:-8]+'_G0240V02_P{0}{1}{2}.nc'.format(int(PPP/10),int((PPP-int(PPP/10)*10)),int((PPP-int(PPP/10)*10-int((PPP-int(PPP/10)*10)))*10))
                     out_nc_filename = './' + out_nc_filename
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
-                    
+
                     from datetime import date
                     d0 = date(np.int(master_split[2][0:4]),np.int(master_split[2][4:6]),np.int(master_split[2][6:8]))
                     d1 = date(np.int(slave_split[2][0:4]),np.int(slave_split[2][4:6]),np.int(slave_split[2][6:8]))
@@ -824,7 +831,13 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
                     error_vector = np.array([57.,57.])
 
-                    no.netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, SY, offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref, XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type, detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_shift_applied, dx_mean_shift, dy_mean_shift, error_vector)
+                    netcdf_file = no.netCDF_packaging(
+                        VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, SY,
+                        offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
+                        XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type,
+                        detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_shift_applied,
+                        dx_mean_shift, dy_mean_shift, error_vector
+                    )
 
                 elif nc_sensor is None:
                     print('netCDF packaging not performed')
@@ -834,6 +847,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
         print("Write Outputs Done!!!")
         print(time.time()-t1)
+
+    return netcdf_file
 
 
 if __name__ == '__main__':

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -229,7 +229,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
                 pixsizex = float(str.split(subprocess.getoutput('fgrep "X-direction pixel size:" testGeogrid.txt'))[-1])
         else:
             chipsizex0 = geogrid_run_info['chipsizex0']
-            pixsizex = geogrid_run_info.get('pixsizex', geogrid_run_info['XPixelSize'])
+            pixsizex = geogrid_run_info['XPixelSize']
         obj.ChipSize0X = int(np.ceil(chipsizex0/pixsizex/4)*4)
 #        obj.ChipSize0X = np.min(CSMINx0[CSMINx0!=nodata])
         RATIO_Y2X = CSMINy0/CSMINx0

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -703,8 +703,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
     #                out_nc_filename = 'Jakobshavn.nc'
                     PPP = roi_valid_percentage * 100
-                    out_nc_filename = master_filename[0:-4]+'_X_'+slave_filename[0:-4]+'_G0240V02_P{0}{1}{2}.nc'.format(int(PPP/10),int((PPP-int(PPP/10)*10)),int((PPP-int(PPP/10)*10-int((PPP-int(PPP/10)*10)))*10))
-                    out_nc_filename = './' + out_nc_filename
+                    out_nc_filename = f"./{master_filename[0:-4]}_X_{slave_filename[0:-4]}" \
+                                      f"_G{geogrid_run_info['chipsizex0']:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
 
@@ -772,8 +772,9 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
     #                out_nc_filename = 'Jakobshavn_opt.nc'
                     PPP = roi_valid_percentage * 100
-                    out_nc_filename = master_filename[0:-8]+'_X_'+slave_filename[0:-8]+'_G0240V02_P{0}{1}{2}.nc'.format(int(PPP/10),int((PPP-int(PPP/10)*10)),int((PPP-int(PPP/10)*10-int((PPP-int(PPP/10)*10)))*10))
-                    out_nc_filename = './' + out_nc_filename
+                    out_nc_filename = f"./{master_filename[0:-8]}_X_{slave_filename[0:-8]}" \
+                                      f"_G{geogrid_run_info['chipsizex0']:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
                     from datetime import date
@@ -837,8 +838,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     coordinates = 'map'
                     roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
                     PPP = roi_valid_percentage * 100
-                    out_nc_filename = master_filename[0:-8]+'_X_'+slave_filename[0:-8]+'_G0240V02_P{0}{1}{2}.nc'.format(int(PPP/10),int((PPP-int(PPP/10)*10)),int((PPP-int(PPP/10)*10-int((PPP-int(PPP/10)*10)))*10))
-                    out_nc_filename = './' + out_nc_filename
+                    out_nc_filename = f"./{master_filename[0:-8]}_X_{slave_filename[0:-8]}" \
+                                      f"_G{geogrid_run_info['chipsizex0']:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
                     from datetime import date

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -389,6 +389,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
     import numpy as np
     import time
 
+    import isce
     from components.contrib.geo_autoRIFT.autoRIFT import __version__ as version
     #  from autoRIFT import __version__ as version
 

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -104,6 +104,7 @@ def loadProductOptical(file_m, file_s):
     '''
     Load the product using Product Manager.
     '''
+    import isce
     from components.contrib.geo_autoRIFT.geogrid import GeogridOptical
 #    from geogrid import GeogridOptical
 
@@ -676,12 +677,14 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                 ############   netCDF packaging for Sentinel and Landsat dataset; can add other sensor format as well
                 if nc_sensor == "S":
                     if geogrid_run_info is None:
+                        chipsizex0 = float(str.split(runCmd('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
                         rangePixelSize = float(str.split(runCmd('fgrep "Ground range pixel size:" testGeogrid.txt'))[4])
                         azimuthPixelSize = float(str.split(runCmd('fgrep "Azimuth pixel size:" testGeogrid.txt'))[3])
                         dt = float(str.split(runCmd('fgrep "Repeat Time:" testGeogrid.txt'))[2])
                         epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
                         #  print (str(rangePixelSize)+"      "+str(azimuthPixelSize))
                     else:
+                        chipsizex0 = geogrid_run_info['chipsizex0']
                         rangePixelSize = geogrid_run_info['rangePixelSize']
                         azimuthPixelSize = geogrid_run_info['azimuthPixelSize']
                         dt = geogrid_run_info['dt']
@@ -705,7 +708,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
     #                out_nc_filename = 'Jakobshavn.nc'
                     PPP = roi_valid_percentage * 100
                     out_nc_filename = f"./{master_filename[0:-4]}_X_{slave_filename[0:-4]}" \
-                                      f"_G{geogrid_run_info['chipsizex0']:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                                      f"_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
 
@@ -736,10 +739,12 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
                 elif nc_sensor == "L":
                     if geogrid_run_info is None:
+                        chipsizex0 = float(str.split(runCmd('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
                         XPixelSize = float(str.split(runCmd('fgrep "X-direction pixel size:" testGeogrid.txt'))[3])
                         YPixelSize = float(str.split(runCmd('fgrep "Y-direction pixel size:" testGeogrid.txt'))[3])
                         epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
                     else:
+                        chipsizex0 = geogrid_run_info['chipsizex0']
                         XPixelSize = geogrid_run_info['XPixelSize']
                         YPixelSize = geogrid_run_info['YPixelSize']
                         epsg = geogrid_run_info['epsg']
@@ -774,7 +779,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
     #                out_nc_filename = 'Jakobshavn_opt.nc'
                     PPP = roi_valid_percentage * 100
                     out_nc_filename = f"./{master_filename[0:-7]}_X_{slave_filename[0:-7]}" \
-                                      f"_G{geogrid_run_info['chipsizex0']:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                                      f"_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
 
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
@@ -807,10 +812,12 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
                 elif nc_sensor == "S2":
                     if geogrid_run_info is None:
+                        chipsizex0 = float(str.split(runCmd('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
                         XPixelSize = float(str.split(runCmd('fgrep "X-direction pixel size:" testGeogrid.txt'))[3])
                         YPixelSize = float(str.split(runCmd('fgrep "Y-direction pixel size:" testGeogrid.txt'))[3])
                         epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
                     else:
+                        chipsizex0 = geogrid_run_info['chipsizex0']
                         XPixelSize = geogrid_run_info['XPixelSize']
                         YPixelSize = geogrid_run_info['YPixelSize']
                         epsg = geogrid_run_info['epsg']
@@ -840,7 +847,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
                     PPP = roi_valid_percentage * 100
                     out_nc_filename = f"./{master_filename[0:-8]}_X_{slave_filename[0:-8]}" \
-                                      f"_G{geogrid_run_info['chipsizex0']:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                                      f"_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
                     from datetime import date

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -685,8 +685,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         #  print (str(rangePixelSize)+"      "+str(azimuthPixelSize))
                     else:
                         chipsizex0 = geogrid_run_info['chipsizex0']
-                        rangePixelSize = geogrid_run_info['rangePixelSize']
-                        azimuthPixelSize = geogrid_run_info['azimuthPixelSize']
+                        rangePixelSize = geogrid_run_info['XPixelSize']
+                        azimuthPixelSize = geogrid_run_info['YPixelSize']
                         dt = geogrid_run_info['dt']
                         epsg = geogrid_run_info['epsg']
 

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -589,7 +589,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                 vyrefname = str.split(runCmd('fgrep "Velocities:" testGeogrid.txt'))[2]
                 sxname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[1][:-4]+"s.tif"
                 syname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[2][:-4]+"s.tif"
-                maskname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[2][:-8]+"masks.tif"
+                maskname = str.split(runCmd('fgrep "Slopes:" testGeogrid.txt'))[2][:-8]+"sp.tif"
                 xoff = int(str.split(runCmd('fgrep "Origin index (in DEM) of geogrid:" testGeogrid.txt'))[6])
                 yoff = int(str.split(runCmd('fgrep "Origin index (in DEM) of geogrid:" testGeogrid.txt'))[7])
                 xcount = int(str.split(runCmd('fgrep "Dimensions of geogrid:" testGeogrid.txt'))[3])

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -772,7 +772,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
     #                out_nc_filename = 'Jakobshavn_opt.nc'
                     PPP = roi_valid_percentage * 100
-                    out_nc_filename = f"./{master_filename[0:-8]}_X_{slave_filename[0:-8]}" \
+                    out_nc_filename = f"./{master_filename[0:-7]}_X_{slave_filename[0:-7]}" \
                                       f"_G{geogrid_run_info['chipsizex0']:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
 
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2


### PR DESCRIPTION
*Note: This PR is required by leiyangleon/Geogrid#7 and allows that PR to be leveraged in autoRIFT*

This:
* Adds some attributes to the `geogrid` object that are needed by autoRIFT:  `pOff`, `lOff`, `pCount`, `lCount`, `X_res`, and `Y_res`. Previously, the only way autoRIFT could receive these values was by `fgrep`-ing a `textGeogrid.txt` log file, which requires subprocessing out Geogrid and makes it harder to setup GDAL + AWS requester pays environments.
* `generateAutoriftProduct` and `runAutorift` now has a `geogrid_run_info` keyword argument to accept the Geogrid `run_info` dictionary
* `maskname = ...+"masks.tif"` has been corrected to ``maskname = ...+"sp.tif"`` as listed in the JPL parameter file
* `generateAutoriftProduct` now returns the name of the output netCDF file

* The netCDF file name's percent valid pixels part has been significantly simplified. Previously, if `PPP=99.6734`, then that percent valid pixels would be reported in the file name like `*_P996.nc`. From a conversation with Mark F., this really should be a 0--100 range, where if every pixel was valid, you'd get `_P100.nc` (previously, you'd actually get `_P1000.nc`).

  Now, if `PPP=996734`, the percent valid pixel part of the file name will be `_P096.nc` and always 3 digits. 
  
  If the previous accuracy (4 digit) is desired, you could change the code to:
  ```python
  PPP = roi_valid_percentage * 1000
  0ut_nc_filename = f"..._P{np.floor(PPP):04.0f}.nc"
  ```
  *Note: this will now have 4 fixed digits instead of "3 but possibly 4".*

* The grid resolution in the netCDF file name (e.g., `G0240`) is now variable based on the DEM resolution
* Landsat-8 scene names are no longer truncated by 1 character in the netCDF file name
