### PR TITLE
other MISC fixes for L8 production

### DIFF
--- a/geo_autoRIFT/geogrid/Geogrid.py
+++ b/geo_autoRIFT/geogrid/Geogrid.py
@@ -63,14 +63,34 @@ class Geogrid(Component):
         ##Create and set parameters
         self.setState()
         
+        ##check parameters
+        self.checkState()
+        
         ##Run
         geogrid.geogrid_Py(self._geogrid)
+        self.get_center_latlon()
         
         ##Get parameters
         self.getState()
 
         ##Clean up
         self.finalize()
+
+    def get_center_latlon(self):
+        '''
+        Get center lat/lon of the image.
+        '''
+        from osgeo import gdal
+        self.epsg = 4326
+        self.determineBbox()
+        if gdal.__version__[0] == '2':
+            self.cen_lat = (self._ylim[0] + self._ylim[1]) / 2
+            self.cen_lon = (self._xlim[0] + self._xlim[1]) / 2
+        else:
+            self.cen_lon = (self._ylim[0] + self._ylim[1]) / 2
+            self.cen_lat = (self._xlim[0] + self._xlim[1]) / 2
+        print("Scene-center lat/lon: " + str(self.cen_lat) + "  " + str(self.cen_lon))
+    
 
     def getProjectionSystem(self):
         '''
@@ -290,6 +310,13 @@ class Geogrid(Component):
 
         self._orbit  = self.orbit.exportToC()
         geogrid.setOrbit_Py(self._geogrid, self._orbit)
+
+    def checkState(self):
+        '''
+        Create C object and populate.
+        '''
+        if self.repeatTime < 0:
+            raise Exception('Input image 1 must be older than input image 2')
 
     def finalize(self):
         '''

--- a/geo_autoRIFT/geogrid/GeogridOptical.py
+++ b/geo_autoRIFT/geogrid/GeogridOptical.py
@@ -53,11 +53,30 @@ class GeogridOptical():
 
         ###Determine extent of data needed
         bbox = self.determineBbox()
-
+        
+        ##check parameters
+        self.checkState()
 
         ##Run
         self.geogrid()
-
+        self.get_center_latlon()
+    
+    def get_center_latlon(self):
+        '''
+        Get center lat/lon of the image.
+        '''
+        from osgeo import gdal
+        self.epsgDem = 4326
+        self.epsgDat = self.getProjectionSystem(self.dat1name)
+        self.determineBbox()
+        if gdal.__version__[0] == '2':
+            self.cen_lat = (self._ylim[0] + self._ylim[1]) / 2
+            self.cen_lon = (self._xlim[0] + self._xlim[1]) / 2
+        else:
+            self.cen_lon = (self._ylim[0] + self._ylim[1]) / 2
+            self.cen_lat = (self._xlim[0] + self._xlim[1]) / 2
+        print("Scene-center lat/lon: " + str(self.cen_lat) + "  " + str(self.cen_lon))
+    
 
     def getProjectionSystem(self, filename):
         '''
@@ -147,7 +166,12 @@ class GeogridOptical():
         self._ylim = [np.min(xyzs[:,1]), np.max(xyzs[:,1])]
 
 
-
+    def checkState(self):
+        '''
+        Create C object and populate.
+        '''
+        if self.repeatTime < 0:
+            raise Exception('Input image 1 must be older than input image 2')
 
 
 

--- a/testGeogridOptical.py
+++ b/testGeogridOptical.py
@@ -148,7 +148,7 @@ def runGeogrid(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, csminy, c
     d0 = date(np.int(info.time[0:4]),np.int(info.time[4:6]),np.int(info.time[6:8]))
     d1 = date(np.int(info1.time[0:4]),np.int(info1.time[4:6]),np.int(info1.time[6:8]))
     date_dt_base = d1 - d0
-    obj.repeatTime = np.abs(date_dt_base.total_seconds())
+    obj.repeatTime = date_dt_base.total_seconds()
 #    obj.repeatTime = (info1.time - info.time) * 24.0 * 3600.0
     obj.numberOfLines = info.numberOfLines
     obj.numberOfSamples = info.numberOfSamples
@@ -196,6 +196,8 @@ def runGeogrid(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, csminy, c
         'epsg': kwargs.get('epsg'),
         'XPixelSize': obj.X_res,
         'YPixelSize': obj.Y_res,
+        'cen_lat': obj.cen_lat,
+        'cen_lon': obj.cen_lon,
     }
 
     return run_info

--- a/testGeogrid_ISCE.py
+++ b/testGeogrid_ISCE.py
@@ -264,6 +264,8 @@ def runGeogrid(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, csminy, c
         'epsg': kwargs.get('epsg'),
         'XPixelSize': obj.X_res,
         'YPixelSize': obj.Y_res,
+        'cen_lat': obj.cen_lat,
+        'cen_lon': obj.cen_lon,
     }
 
     return run_info
@@ -292,7 +294,7 @@ def runGeogridOptical(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, cs
     d0 = date(np.int(info.time[0:4]),np.int(info.time[4:6]),np.int(info.time[6:8]))
     d1 = date(np.int(info1.time[0:4]),np.int(info1.time[4:6]),np.int(info1.time[6:8]))
     date_dt_base = d1 - d0
-    obj.repeatTime = np.abs(date_dt_base.total_seconds())
+    obj.repeatTime = date_dt_base.total_seconds()
 #    obj.repeatTime = (info1.time - info.time) * 24.0 * 3600.0
     obj.numberOfLines = info.numberOfLines
     obj.numberOfSamples = info.numberOfSamples
@@ -340,6 +342,8 @@ def runGeogridOptical(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, cs
         'epsg': kwargs.get('epsg'),
         'XPixelSize': obj.X_res,
         'YPixelSize': obj.Y_res,
+        'cen_lat': obj.cen_lat,
+        'cen_lon': obj.cen_lon,
     }
 
     return run_info

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -77,6 +77,8 @@ def cmdLineParse():
             help='flag for packaging output formatted for Sentinel ("S") and Landsat ("L") dataset; default is None')
     parser.add_argument('-mpflag', '--mpflag', dest='mpflag', type=int, required=False, default=0,
             help='number of threads for multiple threading (default is specified by 0, which uses the original single-core version and surpasses the multithreading routine)')
+    parser.add_argument('-ncname', '--ncname', dest='ncname', type=str, required=False, default=None,
+            help='User-defined filename for the NetCDF output to which the ROI percentage and the production version will be appended')
 
     return parser.parse_args()
 
@@ -386,11 +388,11 @@ def main():
                             chip_size_min=inps.chip_size_min,chip_size_max=inps.chip_size_max,
                             offset2vx=inps.offset2vx, offset2vy=inps.offset2vy,
                             stable_surface_mask=inps.stable_surface_mask, optical_flag=inps.optical_flag,
-                            nc_sensor=inps.nc_sensor, mpflag=inps.mpflag)
+                            nc_sensor=inps.nc_sensor, mpflag=inps.mpflag, ncname=inps.ncname)
 
 
 def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search_range, chip_size_min, chip_size_max,
-                            offset2vx, offset2vy, stable_surface_mask, optical_flag, nc_sensor, mpflag,
+                            offset2vx, offset2vy, stable_surface_mask, optical_flag, nc_sensor, mpflag, ncname,
                             geogrid_run_info=None):
 
     import numpy as np
@@ -739,8 +741,11 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
     #                out_nc_filename = 'Jakobshavn.nc'
                     PPP = roi_valid_percentage * 100
-                    out_nc_filename = f"./{master_filename[0:-4]}_X_{slave_filename[0:-4]}" \
-                                      f"_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                    if ncname is None:
+                        out_nc_filename = f"./{master_filename[0:-4]}_X_{slave_filename[0:-4]}" \
+                                          f"_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                    else:
+                        out_nc_filename = f"{ncname}_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
 
@@ -812,8 +817,11 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
     #                out_nc_filename = 'Jakobshavn_opt.nc'
                     PPP = roi_valid_percentage * 100
-                    out_nc_filename = f"./{master_filename[0:-7]}_X_{slave_filename[0:-7]}" \
-                                      f"_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                    if ncname is None:
+                        out_nc_filename = f"./{master_filename[0:-8]}_X_{slave_filename[0:-8]}" \
+                                          f"_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                    else:
+                        out_nc_filename = f"{ncname}_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
 
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
@@ -882,8 +890,11 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     coordinates = 'map'
                     roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
                     PPP = roi_valid_percentage * 100
-                    out_nc_filename = f"./{master_filename[0:-8]}_X_{slave_filename[0:-8]}" \
-                                      f"_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                    if ncname is None:
+                        out_nc_filename = f"./{master_filename[0:-8]}_X_{slave_filename[0:-8]}" \
+                                          f"_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                    else:
+                        out_nc_filename = f"{ncname}_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
                     from datetime import date

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -481,6 +481,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
         ds = gdal.Open(stable_surface_mask)
         band = ds.GetRasterBand(1)
         SSM = band.ReadAsArray()
+#        SSM = SSM * 0
         SSM = SSM.astype('bool')
         band=None
         ds=None
@@ -609,6 +610,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     yoff = int(str.split(runCmd('fgrep "Origin index (in DEM) of geogrid:" testGeogrid.txt'))[7])
                     xcount = int(str.split(runCmd('fgrep "Dimensions of geogrid:" testGeogrid.txt'))[3])
                     ycount = int(str.split(runCmd('fgrep "Dimensions of geogrid:" testGeogrid.txt'))[5])
+                    cen_lat = int(100*float(str.split(runCmd('fgrep "Scene-center lat/lon:" testGeogrid.txt'))[2]))/100
+                    cen_lon = int(100*float(str.split(runCmd('fgrep "Scene-center lat/lon:" testGeogrid.txt'))[3]))/100
                 else:
                     vxrefname = geogrid_run_info['vxname']
                     vyrefname = geogrid_run_info['vyname']
@@ -619,6 +622,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     yoff = geogrid_run_info['yoff']
                     xcount = geogrid_run_info['xcount']
                     ycount = geogrid_run_info['ycount']
+                    cen_lat = int(100*geogrid_run_info['cen_lat'])/100
+                    cen_lon = int(100*geogrid_run_info['cen_lon'])/100
 
                 ds = gdal.Open(vxrefname)
                 band = ds.GetRasterBand(1)
@@ -654,25 +659,48 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                 DYref = offset2vx_1 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * VYref - offset2vy_1 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * VXref
 
                 stable_count = np.sum(SSM & np.logical_not(np.isnan(DX)) & (DX-DXref > -5) & (DX-DXref < 5) & (DY-DYref > -5) & (DY-DYref < 5))
+                
+                V_temp = np.sqrt(VX**2 + VY**2)
+                V_temp_threshold = np.percentile(V_temp[np.logical_not(np.isnan(V_temp))],25)
+                SSM1 = (V_temp <= V_temp_threshold)
+                
+                stable_count1 = np.sum(SSM1 & np.logical_not(np.isnan(DX)) & (DX-DXref > -5) & (DX-DXref < 5) & (DY-DYref > -5) & (DY-DYref < 5))
 
-                if stable_count == 0:
-                    stable_shift_applied = 0
-                else:
-                    stable_shift_applied = 1
-
-                if stable_shift_applied == 1:
+                dx_mean_shift = 0.0
+                dy_mean_shift = 0.0
+                dx_mean_shift1 = 0.0
+                dy_mean_shift1 = 0.0
+                            
+                if stable_count != 0:
                     temp = DX.copy() - DXref.copy()
                     temp[np.logical_not(SSM)] = np.nan
                     dx_mean_shift = np.median(temp[(temp > -5)&(temp < 5)])
-                    DX = DX - dx_mean_shift
-
+                    
                     temp = DY.copy() - DYref.copy()
                     temp[np.logical_not(SSM)] = np.nan
                     dy_mean_shift = np.median(temp[(temp > -5)&(temp < 5)])
-                    DY = DY - dy_mean_shift
+                    
+                if stable_count1 != 0:
+                    temp = DX.copy() - DXref.copy()
+                    temp[np.logical_not(SSM1)] = np.nan
+                    dx_mean_shift1 = np.median(temp[(temp > -5)&(temp < 5)])
+                    
+                    temp = DY.copy() - DYref.copy()
+                    temp[np.logical_not(SSM1)] = np.nan
+                    dy_mean_shift1 = np.median(temp[(temp > -5)&(temp < 5)])
+                
+                if stable_count == 0:
+                    if stable_count1 == 0:
+                        stable_shift_applied = 0
+                    else:
+                        stable_shift_applied = 2
+                        DX = DX - dx_mean_shift1
+                        DY = DY - dy_mean_shift1
                 else:
-                    dx_mean_shift = 0.0
-                    dy_mean_shift = 0.0
+                    stable_shift_applied = 1
+                    DX = DX - dx_mean_shift
+                    DY = DY - dy_mean_shift
+                
 
                 VX = offset2vx_1 * DX + offset2vx_2 * DY
                 VY = offset2vy_1 * DX + offset2vy_2 * DY
@@ -723,7 +751,9 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     d0 = date(np.int(master_split[5][0:4]),np.int(master_split[5][4:6]),np.int(master_split[5][6:8]))
                     d1 = date(np.int(slave_split[5][0:4]),np.int(slave_split[5][4:6]),np.int(slave_split[5][6:8]))
                     date_dt_base = d1 - d0
-                    date_dt = np.float64(np.abs(date_dt_base.days))
+                    date_dt = np.float64(date_dt_base.days)
+                    if date_dt < 0:
+                        raise Exception('Input image 1 must be older than input image 2')
                     if date_dt_base.days < 0:
                         date_ct = d1 + (d0 - d1)/2
                         date_center = date_ct.strftime("%Y%m%d")
@@ -731,16 +761,16 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         date_ct = d0 + (d1 - d0)/2
                         date_center = date_ct.strftime("%Y%m%d")
 
-                    IMG_INFO_DICT = {'mission_img1':master_split[0][0],'sensor_img1':'C','satellite_img1':master_split[0][1:3],'acquisition_img1':master_dt,'absolute_orbit_number_img1':master_split[7],'mission_data_take_ID_img1':master_split[8],'product_unique_ID_img1':master_split[9][0:4],'mission_img2':slave_split[0][0],'sensor_img2':'C','satellite_img2':slave_split[0][1:3],'acquisition_img2':slave_dt,'absolute_orbit_number_img2':slave_split[7],'mission_data_take_ID_img2':slave_split[8],'product_unique_ID_img2':slave_split[9][0:4],'date_dt':date_dt,'date_center':date_center,'roi_valid_percentage':roi_valid_percentage,'autoRIFT_software_version':version}
+                    IMG_INFO_DICT = {'mission_img1':master_split[0][0],'sensor_img1':'C','satellite_img1':master_split[0][1:3],'acquisition_img1':master_dt,'absolute_orbit_number_img1':master_split[7],'mission_data_take_ID_img1':master_split[8],'product_unique_ID_img1':master_split[9][0:4],'mission_img2':slave_split[0][0],'sensor_img2':'C','satellite_img2':slave_split[0][1:3],'acquisition_img2':slave_dt,'absolute_orbit_number_img2':slave_split[7],'mission_data_take_ID_img2':slave_split[8],'product_unique_ID_img2':slave_split[9][0:4],'date_dt':date_dt,'date_center':date_center,'latitude':cen_lat,'longitude':cen_lon,'roi_valid_percentage':roi_valid_percentage,'autoRIFT_software_version':version}
                     error_vector = np.array([[0.0356, 0.0501, 0.0266, 0.0622, 0.0357, 0.0501],
                                              [0.5194, 1.1638, 0.3319, 1.3701, 0.5191, 1.1628]])
 
                     netcdf_file = no.netCDF_packaging(
-                        VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, SY,
+                        VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1, SX, SY,
                         offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
                         rangePixelSize, azimuthPixelSize, dt, epsg, srs, tran, out_nc_filename, pair_type,
-                        detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_shift_applied,
-                        dx_mean_shift, dy_mean_shift, error_vector
+                        detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
+                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
                     )
 
                 elif nc_sensor == "L":
@@ -793,7 +823,9 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     d0 = date(np.int(master_split[3][0:4]),np.int(master_split[3][4:6]),np.int(master_split[3][6:8]))
                     d1 = date(np.int(slave_split[3][0:4]),np.int(slave_split[3][4:6]),np.int(slave_split[3][6:8]))
                     date_dt_base = d1 - d0
-                    date_dt = np.float64(np.abs(date_dt_base.days))
+                    date_dt = np.float64(date_dt_base.days)
+                    if date_dt < 0:
+                        raise Exception('Input image 1 must be older than input image 2')
                     if date_dt_base.days < 0:
                         date_ct = d1 + (d0 - d1)/2
                         date_center = date_ct.strftime("%Y%m%d")
@@ -804,16 +836,16 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     master_dt = master_split[3][0:8] + master_time.strftime("T%H:%M:%S")
                     slave_dt = slave_split[3][0:8] + slave_time.strftime("T%H:%M:%S")
 
-                    IMG_INFO_DICT = {'mission_img1':master_split[0][0],'sensor_img1':master_split[0][1],'satellite_img1':np.float64(master_split[0][2:4]),'correction_level_img1':master_split[1],'path_img1':np.float64(master_split[2][0:3]),'row_img1':np.float64(master_split[2][3:6]),'acquisition_date_img1':master_dt,'processing_date_img1':master_split[4][0:8],'collection_number_img1':np.float64(master_split[5]),'collection_category_img1':master_split[6],'mission_img2':slave_split[0][0],'sensor_img2':slave_split[0][1],'satellite_img2':np.float64(slave_split[0][2:4]),'correction_level_img2':slave_split[1],'path_img2':np.float64(slave_split[2][0:3]),'row_img2':np.float64(slave_split[2][3:6]),'acquisition_date_img2':slave_dt,'processing_date_img2':slave_split[4][0:8],'collection_number_img2':np.float64(slave_split[5]),'collection_category_img2':slave_split[6],'date_dt':date_dt,'date_center':date_center,'roi_valid_percentage':roi_valid_percentage,'autoRIFT_software_version':version}
+                    IMG_INFO_DICT = {'mission_img1':master_split[0][0],'sensor_img1':master_split[0][1],'satellite_img1':np.float64(master_split[0][2:4]),'correction_level_img1':master_split[1],'path_img1':np.float64(master_split[2][0:3]),'row_img1':np.float64(master_split[2][3:6]),'acquisition_date_img1':master_dt,'processing_date_img1':master_split[4][0:8],'collection_number_img1':np.float64(master_split[5]),'collection_category_img1':master_split[6],'mission_img2':slave_split[0][0],'sensor_img2':slave_split[0][1],'satellite_img2':np.float64(slave_split[0][2:4]),'correction_level_img2':slave_split[1],'path_img2':np.float64(slave_split[2][0:3]),'row_img2':np.float64(slave_split[2][3:6]),'acquisition_date_img2':slave_dt,'processing_date_img2':slave_split[4][0:8],'collection_number_img2':np.float64(slave_split[5]),'collection_category_img2':slave_split[6],'date_dt':date_dt,'date_center':date_center,'latitude':cen_lat,'longitude':cen_lon,'roi_valid_percentage':roi_valid_percentage,'autoRIFT_software_version':version}
 
-                    error_vector = np.array([57.,57.])
+                    error_vector = np.array([25.5,25.5])
 
                     netcdf_file = no.netCDF_packaging(
-                        VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, SY,
+                        VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1, SX, SY,
                         offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
                         XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type,
-                        detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_shift_applied,
-                        dx_mean_shift, dy_mean_shift, error_vector
+                        detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
+                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
                     )
 
                 elif nc_sensor == "S2":
@@ -860,7 +892,9 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     d0 = date(np.int(master_split[2][0:4]),np.int(master_split[2][4:6]),np.int(master_split[2][6:8]))
                     d1 = date(np.int(slave_split[2][0:4]),np.int(slave_split[2][4:6]),np.int(slave_split[2][6:8]))
                     date_dt_base = d1 - d0
-                    date_dt = np.float64(np.abs(date_dt_base.days))
+                    date_dt = np.float64(date_dt_base.days)
+                    if date_dt < 0:
+                        raise Exception('Input image 1 must be older than input image 2')
                     if date_dt_base.days < 0:
                         date_ct = d1 + (d0 - d1)/2
                         date_center = date_ct.strftime("%Y%m%d")
@@ -871,16 +905,16 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     master_dt = master_split[2] + master_time.strftime("T%H:%M:%S")
                     slave_dt = slave_split[2] + slave_time.strftime("T%H:%M:%S")
 
-                    IMG_INFO_DICT = {'mission_img1':master_split[0][-3],'satellite_img1':master_split[0][-2:],'correction_level_img1':master_split[4][:3],'acquisition_date_img1':master_dt,'mission_img2':slave_split[0][-3],'satellite_img2':slave_split[0][-2:],'correction_level_img2':slave_split[4][:3],'acquisition_date_img2':slave_dt,'date_dt':date_dt,'date_center':date_center,'roi_valid_percentage':roi_valid_percentage,'autoRIFT_software_version':version}
+                    IMG_INFO_DICT = {'mission_img1':master_split[0][-3],'satellite_img1':master_split[0][-2:],'correction_level_img1':master_split[4][:3],'acquisition_date_img1':master_dt,'mission_img2':slave_split[0][-3],'satellite_img2':slave_split[0][-2:],'correction_level_img2':slave_split[4][:3],'acquisition_date_img2':slave_dt,'date_dt':date_dt,'date_center':date_center,'latitude':cen_lat,'longitude':cen_lon,'roi_valid_percentage':roi_valid_percentage,'autoRIFT_software_version':version}
 
-                    error_vector = np.array([57.,57.])
+                    error_vector = np.array([25.5,25.5])
 
                     netcdf_file = no.netCDF_packaging(
-                        VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SX, SY,
+                        VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1, SX, SY,
                         offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, MM, VXref, VYref,
                         XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type,
-                        detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_shift_applied,
-                        dx_mean_shift, dy_mean_shift, error_vector
+                        detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
+                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
                     )
 
                 elif nc_sensor is None:

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -77,6 +77,8 @@ def cmdLineParse():
             help='flag for packaging output formatted for Sentinel ("S") and Landsat ("L") dataset; default is None')
     parser.add_argument('-mpflag', '--mpflag', dest='mpflag', type=int, required=False, default=0,
             help='number of threads for multiple threading (default is specified by 0, which uses the original single-core version and surpasses the multithreading routine)')
+    parser.add_argument('-ncname', '--ncname', dest='ncname', type=str, required=False, default=None,
+            help='User-defined filename for the NetCDF output to which the ROI percentage and the production version will be appended')
 
     return parser.parse_args()
 
@@ -386,11 +388,11 @@ def main():
                             chip_size_min=inps.chip_size_min,chip_size_max=inps.chip_size_max,
                             offset2vx=inps.offset2vx, offset2vy=inps.offset2vy,
                             stable_surface_mask=inps.stable_surface_mask, optical_flag=inps.optical_flag,
-                            nc_sensor=inps.nc_sensor, mpflag=inps.mpflag)
+                            nc_sensor=inps.nc_sensor, mpflag=inps.mpflag, ncname=inps.ncname)
 
 
 def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search_range, chip_size_min, chip_size_max,
-                            offset2vx, offset2vy, stable_surface_mask, optical_flag, nc_sensor, mpflag,
+                            offset2vx, offset2vy, stable_surface_mask, optical_flag, nc_sensor, mpflag, ncname,
                             geogrid_run_info=None):
 
     import numpy as np
@@ -741,8 +743,11 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
     #                out_nc_filename = 'Jakobshavn.nc'
                     PPP = roi_valid_percentage * 100
-                    out_nc_filename = f"./{master_filename[0:-4]}_X_{slave_filename[0:-4]}" \
-                                      f"_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                    if ncname is None:
+                        out_nc_filename = f"./{master_filename[0:-4]}_X_{slave_filename[0:-4]}" \
+                                          f"_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                    else:
+                        out_nc_filename = f"{ncname}_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
 
@@ -814,9 +819,11 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
     #                out_nc_filename = 'Jakobshavn_opt.nc'
                     PPP = roi_valid_percentage * 100
-                    out_nc_filename = f"./{master_filename[0:-7]}_X_{slave_filename[0:-7]}" \
-                                      f"_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
-
+                    if ncname is None:
+                        out_nc_filename = f"./{master_filename[0:-8]}_X_{slave_filename[0:-8]}" \
+                                          f"_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                    else:
+                        out_nc_filename = f"{ncname}_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
                     from datetime import date
@@ -884,8 +891,11 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     coordinates = 'map'
                     roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
                     PPP = roi_valid_percentage * 100
-                    out_nc_filename = f"./{master_filename[0:-8]}_X_{slave_filename[0:-8]}" \
-                                      f"_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                    if ncname is None:
+                        out_nc_filename = f"./{master_filename[0:-8]}_X_{slave_filename[0:-8]}" \
+                                          f"_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
+                    else:
+                        out_nc_filename = f"{ncname}_G{chipsizex0:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
                     from datetime import date


### PR DESCRIPTION
- add condition check to both autoRIFT and Geogrid, and make sure Image1 is older than Image2
- add second estimate of velocity error when stable surface mask is invalid, and update both the error and stable shift in NETCDF output (not included here)
- add scene-center latitude/longitude 
- add command-line optional filename of NetCDF output