### PR TITLE
add dt-varying search range routine

### DIFF
--- a/geo_autoRIFT/geogrid/Geogrid.py
+++ b/geo_autoRIFT/geogrid/Geogrid.py
@@ -268,6 +268,11 @@ class Geogrid(Component):
         geogrid.setRangeParameters_Py( self._geogrid, self.startingRange, self.rangePixelSize)
         geogrid.setAzimuthParameters_Py( self._geogrid, DTU.seconds_since_midnight(self.sensingStart), self.prf)
         geogrid.setRepeatTime_Py(self._geogrid, self.repeatTime)
+        
+        geogrid.setDtUnity_Py( self._geogrid, self.dt_unity)
+        geogrid.setMaxFactor_Py( self._geogrid, self.max_factor)
+        geogrid.setUpperThreshold_Py( self._geogrid, self.upper_thld)
+        geogrid.setLowerThreshold_Py(self._geogrid, self.lower_thld)
 
         geogrid.setEPSG_Py(self._geogrid, self.epsg)
         geogrid.setIncidenceAngle_Py(self._geogrid, self.incidenceAngle)
@@ -373,7 +378,11 @@ class Geogrid(Component):
         self.winro2vxname = None
         self.winro2vyname = None
 
-
+        ##dt-varying search range rountine parameters
+        self.dt_unity = 182
+        self.max_factor = 5
+        self.upper_thld = 20000
+        self.lower_thld = 0
 
         ##Coordinate system
         self.epsg = None

--- a/geo_autoRIFT/geogrid/GeogridOptical.py
+++ b/geo_autoRIFT/geogrid/GeogridOptical.py
@@ -570,7 +570,11 @@ class GeogridOptical():
                     vel = np.array([0., 0., 0.])
                 if (self.srxname != ""):
                     schrng1 = np.array([srxLine[jj], sryLine[jj], 0.0])
-                    schrng2 = np.array([-srxLine[jj], sryLine[jj], 0.0])
+                    schrng1[0] *= np.max((self.max_factor*((self.dt_unity-1)*self.max_factor+(self.max_factor-1)-(self.max_factor-1)*self.repeatTime/24.0/3600.0)/((self.dt_unity-1)*self.max_factor),1))
+                    schrng1[0] = np.min((np.max((schrng1[0],self.lower_thld)),self.upper_thld))
+                    schrng1[1] *= np.max((self.max_factor*((self.dt_unity-1)*self.max_factor+(self.max_factor-1)-(self.max_factor-1)*self.repeatTime/24.0/3600.0)/((self.dt_unity-1)*self.max_factor),1))
+                    schrng1[1] = np.min((np.max((schrng1[1],self.lower_thld)),self.upper_thld))
+                    schrng2 = np.array([-schrng1[0], schrng1[1], 0.0])
                 targutm0 = np.array(fwdTrans.TransformPoint(targxyz0[0],targxyz0[1],targxyz0[2]))
                 xind = np.round((targutm0[0] - self.startingX) / self.XSize) + 1.
                 yind = np.round((targutm0[1] - self.startingY) / self.YSize) + 1.
@@ -862,6 +866,12 @@ class GeogridOptical():
         self.winssmname = None
         self.winro2vxname = None
         self.winro2vyname = None
+        
+        ##dt-varying search range rountine parameters
+        self.dt_unity = 182
+        self.max_factor = 5
+        self.upper_thld = 20000
+        self.lower_thld = 0
 
         ##Coordinate system
         self.epsgDem = None

--- a/geo_autoRIFT/geogrid/bindings/geogridmodule.cpp
+++ b/geo_autoRIFT/geogrid/bindings/geogridmodule.cpp
@@ -539,6 +539,54 @@ PyObject* getYPixelSize(PyObject *self, PyObject *args)
     return Py_BuildValue("d",var);
 }
 
+PyObject* setDtUnity(PyObject *self, PyObject *args)
+{
+    uint64_t ptr;
+    double dt_unity;
+    if (!PyArg_ParseTuple(args, "Kd", &ptr, &dt_unity))
+    {
+        return NULL;
+    }
+    ((geoGrid*)(ptr))->dt_unity = dt_unity;
+    return Py_BuildValue("i", 0);
+}
+
+PyObject* setMaxFactor(PyObject *self, PyObject *args)
+{
+    uint64_t ptr;
+    double max_factor;
+    if (!PyArg_ParseTuple(args, "Kd", &ptr, &max_factor))
+    {
+        return NULL;
+    }
+    ((geoGrid*)(ptr))->max_factor = max_factor;
+    return Py_BuildValue("i", 0);
+}
+
+PyObject* setUpperThreshold(PyObject *self, PyObject *args)
+{
+    uint64_t ptr;
+    double upper_thld;
+    if (!PyArg_ParseTuple(args, "Kd", &ptr, &upper_thld))
+    {
+        return NULL;
+    }
+    ((geoGrid*)(ptr))->upper_thld = upper_thld;
+    return Py_BuildValue("i", 0);
+}
+
+PyObject* setLowerThreshold(PyObject *self, PyObject *args)
+{
+    uint64_t ptr;
+    double lower_thld;
+    if (!PyArg_ParseTuple(args, "Kd", &ptr, &lower_thld))
+    {
+        return NULL;
+    }
+    ((geoGrid*)(ptr))->lower_thld = lower_thld;
+    return Py_BuildValue("i", 0);
+}
+
 
 PyObject* geogrid(PyObject* self, PyObject* args)
 {

--- a/geo_autoRIFT/geogrid/include/geogrid.h
+++ b/geo_autoRIFT/geogrid/include/geogrid.h
@@ -73,6 +73,11 @@ struct geoGrid
     double incidenceAngle;
     int pOff, lOff, pCount, lCount;
     double grd_res, azm_res;
+    
+    //dt-varying search range rountine parameters
+    double dt_unity;
+    double max_factor;
+    double upper_thld, lower_thld;
 
     //Output file names
     std::string pixlinename;

--- a/geo_autoRIFT/geogrid/include/geogridmodule.h
+++ b/geo_autoRIFT/geogrid/include/geogridmodule.h
@@ -53,6 +53,11 @@ extern "C"
         PyObject * setOrbit(PyObject *, PyObject *);
         PyObject * setLookSide(PyObject *, PyObject *);
         PyObject * setNodataOut(PyObject *, PyObject *);
+    
+        PyObject * setDtUnity(PyObject *, PyObject *);
+        PyObject * setMaxFactor(PyObject *, PyObject *);
+        PyObject * setUpperThreshold(PyObject*, PyObject *);
+        PyObject * setLowerThreshold(PyObject *, PyObject *);
 
         PyObject * setWindowLocationsFilename(PyObject *, PyObject *);
         PyObject * setWindowOffsetsFilename(PyObject *, PyObject *);
@@ -99,6 +104,10 @@ static PyMethodDef geogrid_methods[] =
         {"setOrbit_Py", setOrbit, METH_VARARGS, " "},
         {"setLookSide_Py", setLookSide, METH_VARARGS, " "},
         {"setNodataOut_Py", setNodataOut, METH_VARARGS, " "},
+        {"setDtUnity_Py", setDtUnity, METH_VARARGS, " "},
+        {"setMaxFactor_Py", setMaxFactor, METH_VARARGS, " "},
+        {"setUpperThreshold_Py", setUpperThreshold, METH_VARARGS, " "},
+        {"setLowerThreshold_Py", setLowerThreshold, METH_VARARGS, " "},
         {"setXLimits_Py", setXLimits, METH_VARARGS, " "},
         {"setYLimits_Py", setYLimits, METH_VARARGS, " "},
         {"getXPixelSize_Py", getXPixelSize, METH_VARARGS, " "},

--- a/geo_autoRIFT/geogrid/src/geogrid.cpp
+++ b/geo_autoRIFT/geogrid/src/geogrid.cpp
@@ -927,11 +927,15 @@ void geoGrid::geogrid()
             {
                 schrng1[0] = srxLine[jj];
                 schrng1[1] = sryLine[jj];
-                schrng2[0] = -srxLine[jj];
-                schrng2[1] = sryLine[jj];
+            
+                schrng1[0] *= std::max(max_factor*((dt_unity-1)*max_factor+(max_factor-1)-(max_factor-1)*dt/24.0/3600.0)/((dt_unity-1)*max_factor),1.0);
+                schrng1[0] = std::min(std::max(schrng1[0],lower_thld),upper_thld);
+                schrng1[1] *= std::max(max_factor*((dt_unity-1)*max_factor+(max_factor-1)-(max_factor-1)*dt/24.0/3600.0)/((dt_unity-1)*max_factor),1.0);
+                schrng1[1] = std::min(std::max(schrng1[1],lower_thld),upper_thld);
+            
+                schrng2[0] = -schrng1[0];
+                schrng2[1] = schrng1[1];
             }
-            
-            
             
 
             //Convert from DEM coordinates to LLH inplace

--- a/testGeogridOptical.py
+++ b/testGeogridOptical.py
@@ -171,6 +171,10 @@ def runGeogrid(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, csminy, c
     obj.ssmname = ssm
     obj.winlocname = "window_location.tif"
     obj.winoffname = "window_offset.tif"
+#    obj.max_factor = 10
+#    obj.dt_unity = 32
+#    obj.upper_thld = 20000
+#    obj.lower_thld = 0
     obj.winsrname = "window_search_range.tif"
     obj.wincsminname = "window_chip_size_min.tif"
     obj.wincsmaxname = "window_chip_size_max.tif"

--- a/testGeogrid_ISCE.py
+++ b/testGeogrid_ISCE.py
@@ -238,6 +238,10 @@ def runGeogrid(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, csminy, c
     obj.ssmname = ssm
     obj.winlocname = "window_location.tif"
     obj.winoffname = "window_offset.tif"
+#    obj.max_factor = 10
+#    obj.dt_unity = 5
+#    obj.upper_thld = 20000
+#    obj.lower_thld = 0
     obj.winsrname = "window_search_range.tif"
     obj.wincsminname = "window_chip_size_min.tif"
     obj.wincsmaxname = "window_chip_size_max.tif"
@@ -317,6 +321,10 @@ def runGeogridOptical(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, cs
     obj.ssmname = ssm
     obj.winlocname = "window_location.tif"
     obj.winoffname = "window_offset.tif"
+#    obj.max_factor = 10
+#    obj.dt_unity = 32
+#    obj.upper_thld = 20000
+#    obj.lower_thld = 0
     obj.winsrname = "window_search_range.tif"
     obj.wincsminname = "window_chip_size_min.tif"
     obj.wincsmaxname = "window_chip_size_max.tif"


### PR DESCRIPTION
Adding dt-varying search range routine with 4 parameters: `dt_unity`, `max_factor`, `upper_thld` and `lower_thld`. This is useful in areas with large seasonal variability of velocity.

Original search range will be multiplied by a factor which is defined as:

- `max_factor` when `dt = 1`
- `1` when `dt >= dt_unity`
- linearly drops from  `max_factor` to `1` when `1 <= dt <= dt_unity`

The resulting search range in unit of m/yr will be then truncated based on the upper and lower thresholds (`upper_thld` and `lower_thld`) that user provided.

By default,  these parameters are set to:
`dt_unity = 182` (unit of days),
`max_factor = 5` (unitless), 
`upper_thld = 20000` (unit of m/yr),
`lower_thld = 0` (unit of m/yr)

Users can easily change these four parameters in testGeogrid script where some example lines have already been provided (but commented out) for setting values of the four parameters here.