### PR TITLE
update dt-varying search range routine

### DIFF
--- a/geo_autoRIFT/geogrid/Geogrid.py
+++ b/geo_autoRIFT/geogrid/Geogrid.py
@@ -269,10 +269,10 @@ class Geogrid(Component):
         geogrid.setAzimuthParameters_Py( self._geogrid, DTU.seconds_since_midnight(self.sensingStart), self.prf)
         geogrid.setRepeatTime_Py(self._geogrid, self.repeatTime)
         
-        geogrid.setDtUnity_Py( self._geogrid, self.dt_unity)
-        geogrid.setMaxFactor_Py( self._geogrid, self.max_factor)
-        geogrid.setUpperThreshold_Py( self._geogrid, self.upper_thld)
-        geogrid.setLowerThreshold_Py(self._geogrid, self.lower_thld)
+        geogrid.setDtUnity_Py( self._geogrid, self.srs_dt_unity)
+        geogrid.setMaxFactor_Py( self._geogrid, self.srs_max_scale)
+        geogrid.setUpperThreshold_Py( self._geogrid, self.srs_max_search)
+        geogrid.setLowerThreshold_Py(self._geogrid, self.srs_min_search)
 
         geogrid.setEPSG_Py(self._geogrid, self.epsg)
         geogrid.setIncidenceAngle_Py(self._geogrid, self.incidenceAngle)
@@ -377,12 +377,12 @@ class Geogrid(Component):
         self.winssmname = None
         self.winro2vxname = None
         self.winro2vyname = None
-
-        ##dt-varying search range rountine parameters
-        self.dt_unity = 182
-        self.max_factor = 5
-        self.upper_thld = 20000
-        self.lower_thld = 0
+        
+        ##dt-varying search range scale (srs) rountine parameters
+        self.srs_dt_unity = 182
+        self.srs_max_scale = 5
+        self.srs_max_search = 20000
+        self.srs_min_search = 0
 
         ##Coordinate system
         self.epsg = None

--- a/geo_autoRIFT/geogrid/GeogridOptical.py
+++ b/geo_autoRIFT/geogrid/GeogridOptical.py
@@ -235,7 +235,10 @@ class GeogridOptical():
 
         print("Starting processing .... ")
 
-
+        dt_unity = self.srs_dt_unity
+        max_factor = self.srs_max_scale
+        upper_thld = self.srs_max_search
+        lower_thld = self.srs_min_search
 
 
         from osgeo import gdal, osr
@@ -570,10 +573,10 @@ class GeogridOptical():
                     vel = np.array([0., 0., 0.])
                 if (self.srxname != ""):
                     schrng1 = np.array([srxLine[jj], sryLine[jj], 0.0])
-                    schrng1[0] *= np.max((self.max_factor*((self.dt_unity-1)*self.max_factor+(self.max_factor-1)-(self.max_factor-1)*self.repeatTime/24.0/3600.0)/((self.dt_unity-1)*self.max_factor),1))
-                    schrng1[0] = np.min((np.max((schrng1[0],self.lower_thld)),self.upper_thld))
-                    schrng1[1] *= np.max((self.max_factor*((self.dt_unity-1)*self.max_factor+(self.max_factor-1)-(self.max_factor-1)*self.repeatTime/24.0/3600.0)/((self.dt_unity-1)*self.max_factor),1))
-                    schrng1[1] = np.min((np.max((schrng1[1],self.lower_thld)),self.upper_thld))
+                    schrng1[0] *= np.max((max_factor*((dt_unity-1)*max_factor+(max_factor-1)-(max_factor-1)*self.repeatTime/24.0/3600.0)/((dt_unity-1)*max_factor),1))
+                    schrng1[0] = np.min((np.max((schrng1[0],lower_thld)),upper_thld))
+                    schrng1[1] *= np.max((max_factor*((dt_unity-1)*max_factor+(max_factor-1)-(max_factor-1)*self.repeatTime/24.0/3600.0)/((dt_unity-1)*max_factor),1))
+                    schrng1[1] = np.min((np.max((schrng1[1],lower_thld)),upper_thld))
                     schrng2 = np.array([-schrng1[0], schrng1[1], 0.0])
                 targutm0 = np.array(fwdTrans.TransformPoint(targxyz0[0],targxyz0[1],targxyz0[2]))
                 xind = np.round((targutm0[0] - self.startingX) / self.XSize) + 1.
@@ -867,11 +870,11 @@ class GeogridOptical():
         self.winro2vxname = None
         self.winro2vyname = None
         
-        ##dt-varying search range rountine parameters
-        self.dt_unity = 182
-        self.max_factor = 5
-        self.upper_thld = 20000
-        self.lower_thld = 0
+        ##dt-varying search range scale (srs) rountine parameters
+        self.srs_dt_unity = 182
+        self.srs_max_scale = 5
+        self.srs_max_search = 20000
+        self.srs_min_search = 0
 
         ##Coordinate system
         self.epsgDem = None

--- a/testGeogridOptical.py
+++ b/testGeogridOptical.py
@@ -171,16 +171,17 @@ def runGeogrid(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, csminy, c
     obj.ssmname = ssm
     obj.winlocname = "window_location.tif"
     obj.winoffname = "window_offset.tif"
-#    obj.max_factor = 10
-#    obj.dt_unity = 32
-#    obj.upper_thld = 20000
-#    obj.lower_thld = 0
     obj.winsrname = "window_search_range.tif"
     obj.wincsminname = "window_chip_size_min.tif"
     obj.wincsmaxname = "window_chip_size_max.tif"
     obj.winssmname = "window_stable_surface_mask.tif"
     obj.winro2vxname = "window_rdr_off2vel_x_vec.tif"
     obj.winro2vyname = "window_rdr_off2vel_y_vec.tif"
+    ##dt-varying search range scale (srs) rountine parameters
+#    obj.srs_dt_unity = 32
+#    obj.srs_max_scale = 10
+#    obj.srs_max_search = 20000
+#    obj.srs_min_search = 0
 
     obj.runGeogrid()
 

--- a/testGeogrid_ISCE.py
+++ b/testGeogrid_ISCE.py
@@ -238,16 +238,17 @@ def runGeogrid(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, csminy, c
     obj.ssmname = ssm
     obj.winlocname = "window_location.tif"
     obj.winoffname = "window_offset.tif"
-#    obj.max_factor = 10
-#    obj.dt_unity = 5
-#    obj.upper_thld = 20000
-#    obj.lower_thld = 0
     obj.winsrname = "window_search_range.tif"
     obj.wincsminname = "window_chip_size_min.tif"
     obj.wincsmaxname = "window_chip_size_max.tif"
     obj.winssmname = "window_stable_surface_mask.tif"
     obj.winro2vxname = "window_rdr_off2vel_x_vec.tif"
     obj.winro2vyname = "window_rdr_off2vel_y_vec.tif"
+    ##dt-varying search range scale (srs) rountine parameters
+#    obj.srs_dt_unity = 5
+#    obj.srs_max_scale = 10
+#    obj.srs_max_search = 20000
+#    obj.srs_min_search = 0
 
     obj.getIncidenceAngle()
     obj.geogrid()
@@ -321,16 +322,17 @@ def runGeogridOptical(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, cs
     obj.ssmname = ssm
     obj.winlocname = "window_location.tif"
     obj.winoffname = "window_offset.tif"
-#    obj.max_factor = 10
-#    obj.dt_unity = 32
-#    obj.upper_thld = 20000
-#    obj.lower_thld = 0
     obj.winsrname = "window_search_range.tif"
     obj.wincsminname = "window_chip_size_min.tif"
     obj.wincsmaxname = "window_chip_size_max.tif"
     obj.winssmname = "window_stable_surface_mask.tif"
     obj.winro2vxname = "window_rdr_off2vel_x_vec.tif"
     obj.winro2vyname = "window_rdr_off2vel_y_vec.tif"
+    ##dt-varying search range scale (srs) rountine parameters
+#    obj.srs_dt_unity = 32
+#    obj.srs_max_scale = 10
+#    obj.srs_max_search = 20000
+#    obj.srs_min_search = 0
 
     obj.runGeogrid()
 


### PR DESCRIPTION
rename dt-varying "search range scale" (srs) rountine parameters that were introduced in PR #26 

```
srs_dt_unity (default = 182) (unit of days),
srs_max_scale (default = 5) (unitless),
srs_max_search (default  = 20000) (unit of m/yr),
srs_min_search (default = 0) (unit of m/yr)
```