### PR TITLE
Proposed edits with respect to number of lines and samples

### DIFF
--- a/testGeogrid_ISCE.py
+++ b/testGeogrid_ISCE.py
@@ -218,8 +218,17 @@ def runGeogrid(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, csminy, c
     obj.prf = info.prf
     obj.lookSide = info.lookSide
     obj.repeatTime = (info1.sensingStart - info.sensingStart).total_seconds()
-    obj.numberOfLines = info.numberOfLines
-    obj.numberOfSamples = info.numberOfSamples
+    
+    #Checks the appropriate number of lines and samples that are in overlap between the reference and secondary images
+    if info.numberOfLines <= info1.numberOfLines:
+        obj.numberOfLines = info.numberOfLines
+    else:
+        obj.numberOfLines = info1.numberOfLines
+    if info.numberOfSamples <= info1.numberOfSamples:
+        obj.numberOfSamples = info.numberOfSamples
+    else:
+        obj.numberOfSamples = info1.numberOfSamples
+    
     obj.nodata_out = -32767
     obj.chipSizeX0 = 240
     obj.gridSpacingX = dem_info['geoTransform'][1]


### PR DESCRIPTION
I found that my problem regarding the issue https://github.com/leiyangleon/autoRIFT/issues/31 was due to having two Sentinel-1 adjacent reference images and having one secondary images. The code doesn't take into account the overlap between the number of lines and samples. I found out that the overlap is based on which of the reference or the secondary images have less number of samples and lines. These also match the dimensions of reference.slc.full and secondary.slc.full which are used on the testautoRIFT_ISCE.py.

Hence, I'm proposing edits to possibly resolved the issue.