### PR TITLE
Use OpenMP's Dynamic Thread Scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2]
+
+### Fixed
+- The search functions in `autoriftcoremodule.cpp`, `arPixDisp_` and `arSubPixDisp_`, now use OpenMP's dynamic thread scheduling for improved performance.
+
 ## [2.1.1]
 
 ### Fixed

--- a/geo_autoRIFT/autoRIFT/bindings/autoriftcoremodule.cpp
+++ b/geo_autoRIFT/autoRIFT/bindings/autoriftcoremodule.cpp
@@ -119,9 +119,9 @@ PyObject *arPixDisp_u(PyObject *self, PyObject *args) {
   cv::Mat chip_size_x = cv::Mat(cv::Size(widX, lenX), CV_32FC1, reinterpret_cast<float *>(PyArray_DATA(ChipSizeX)));
   cv::Mat chip_size_y = cv::Mat(cv::Size(widX, lenX), CV_32FC1, reinterpret_cast<float *>(PyArray_DATA(ChipSizeY)));
 
-#pragma omp parallel for collapse(2)
-  for (int j = 0; j < widX; j++) {
-    for (int i = 0; i < lenX; i++) {
+  #pragma omp parallel for schedule(dynamic, 1)
+  for (int i = 0; i < lenX; i++) {
+    for (int j = 0; j < widX; j++) {
       if (search_limit_x.at<float>(i, j) == 0 and search_limit_y.at<float>(i, j) == 0) {
         continue;
       }
@@ -211,9 +211,9 @@ PyObject *arSubPixDisp_u(PyObject *self, PyObject *args) {
   cv::Mat chip_size_x = cv::Mat(cv::Size(widX, lenX), CV_32FC1, reinterpret_cast<float *>(PyArray_DATA(ChipSizeX)));
   cv::Mat chip_size_y = cv::Mat(cv::Size(widX, lenX), CV_32FC1, reinterpret_cast<float *>(PyArray_DATA(ChipSizeY)));
 
-#pragma omp parallel for collapse(2)
-  for (int j = 0; j < widX; j++) {
-    for (int i = 0; i < lenX; i++) {
+  #pragma omp parallel for schedule(dynamic, 1)
+  for (int i = 0; i < lenX; i++) {
+    for (int j = 0; j < widX; j++) {
       if (search_limit_x.at<float>(i, j) == 0 and search_limit_y.at<float>(i, j) == 0) {
         continue;
       }
@@ -333,9 +333,9 @@ PyObject *arPixDisp_s(PyObject *self, PyObject *args) {
   cv::Mat chip_size_x = cv::Mat(cv::Size(widX, lenX), CV_32FC1, reinterpret_cast<float *>(PyArray_DATA(ChipSizeX)));
   cv::Mat chip_size_y = cv::Mat(cv::Size(widX, lenX), CV_32FC1, reinterpret_cast<float *>(PyArray_DATA(ChipSizeY)));
 
-#pragma omp parallel for collapse(2)
-  for (int j = 0; j < widX; j++) {
-    for (int i = 0; i < lenX; i++) {
+  #pragma omp parallel for schedule(dynamic, 1)
+  for (int i = 0; i < lenX; i++) {
+    for (int j = 0; j < widX; j++) {
       if (search_limit_x.at<float>(i, j) == 0 and search_limit_y.at<float>(i, j) == 0) {
         continue;
       }
@@ -425,9 +425,10 @@ PyObject *arSubPixDisp_s(PyObject *self, PyObject *args) {
   cv::Mat chip_size_x = cv::Mat(cv::Size(widX, lenX), CV_32FC1, reinterpret_cast<float *>(PyArray_DATA(ChipSizeX)));
   cv::Mat chip_size_y = cv::Mat(cv::Size(widX, lenX), CV_32FC1, reinterpret_cast<float *>(PyArray_DATA(ChipSizeY)));
 
-#pragma omp parallel for collapse(2)
-  for (int j = 0; j < widX; j++) {
-    for (int i = 0; i < lenX; i++) {
+
+  #pragma omp parallel for schedule(dynamic, 1)
+  for (int i = 0; i < lenX; i++) {
+    for (int j = 0; j < widX; j++) {
       if (search_limit_x.at<float>(i, j) == 0 and search_limit_y.at<float>(i, j) == 0) {
         continue;
       }


### PR DESCRIPTION
Currently, the OpenMP multithreading in `autoriftcoremodule.cpp` uses static thread scheduling. This means that the data is split into an even number of blocks, and distributed evenly to the available threads, prior to doing any work. Threads with more "simple" blocks may finish before the threads with "complex" blocks, and then they sit around doing nothing. 

With dynamic scheduling, the threads are able to pick up the next block of data that isn't being worked on by another thread whenever it completes one. This can significantly improve performance for scenes where the complexity of the search process varies over the image, i.e. scenes with more than one search range.

For example, the fine search for the following pair takes ~4000 seconds with static scheduling, and ~1000 seconds with dynamic scheduling:
```
NISAR_L1_PR_RSLC_003_170_D_053_7700_SHNA_A_20251028T235201_20251028T235238_X05009_N_P_J_001
NISAR_L1_PR_RSLC_007_170_D_053_7700_SHNA_A_20251215T235203_20251215T235240_X05009_N_P_J_001
```